### PR TITLE
Fix crash with 1 mp starting unit

### DIFF
--- a/mods/raclassic/rules/world.yaml
+++ b/mods/raclassic/rules/world.yaml
@@ -93,7 +93,7 @@ World:
 		Factions: allies, soviet
 		BaseActor: mcv
 		SupportActors: e1
-		InnerSupportRadius: 3
+		InnerSupportRadius: 2
 		OuterSupportRadius: 3
 	MPStartUnits@2_allies:
 		Class: 2


### PR DESCRIPTION
Occurs because SpawnMPUnits adds `+1` to `InnerSupportRadius` when finding an annulus to spawn units in, which won't work.