### PR TITLE
Changed some weapons to use large explosion as in original

### DIFF
--- a/mods/raclassic/rules/defaults.yaml
+++ b/mods/raclassic/rules/defaults.yaml
@@ -521,9 +521,6 @@
 		RequiredForShortGame: false
 	DrawLineToTarget:
 	RenderRangeCircle:
-	Explodes:
-		Weapon: SmallBuildingExplode
-		EmptyWeapon: SmallBuildingExplode
 	EditorTilesetFilter:
 		Categories: Defense
 	-CommandBarBlacklist:

--- a/mods/raclassic/rules/structures.yaml
+++ b/mods/raclassic/rules/structures.yaml
@@ -81,9 +81,6 @@ GAP:
 		Amount: -90
 	MustBeDestroyed:
 		RequiredForShortGame: false
-	Explodes:
-		Weapon: SmallBuildingExplode
-		EmptyWeapon: SmallBuildingExplode
 	HitShape:
 		Type: Rectangle
 			TopLeft: -512, -512
@@ -608,9 +605,6 @@ FTUR:
 	DetectCloaked:
 		Range: 6c0
 	ProvidesPrerequisite@buildingname:
-	Explodes:
-		Weapon: BuildingExplode
-		EmptyWeapon: BuildingExplode
 
 SAM:
 	Inherits: ^Defense
@@ -902,9 +896,6 @@ SILO:
 	-EmitInfantryOnSell:
 	Power:
 		Amount: -10
-	Explodes:
-		Weapon: SmallBuildingExplode
-		EmptyWeapon: SmallBuildingExplode
 
 HPAD:
 	Inherits: ^Building

--- a/mods/raclassic/weapons/ballistics.yaml
+++ b/mods/raclassic/weapons/ballistics.yaml
@@ -96,7 +96,7 @@ TurretGun:
 			Concrete: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
-		Explosions: artillery_explosion
+		Explosions: building
 		ImpactSounds: kaboom15.aud
 	Warhead@4EffWater: CreateEffect
 		Explosions: med_splash

--- a/mods/raclassic/weapons/explosions.yaml
+++ b/mods/raclassic/weapons/explosions.yaml
@@ -96,18 +96,13 @@ V2Explode:
 
 BuildingExplode:
 	Warhead@2Eff: CreateEffect
-		Explosions: building, building_napalm, large_explosion, self_destruct, large_napalm
+		Explosions: building
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Crater
 		InvalidTargets: Wall, Trees
 
-SmallBuildingExplode:
-	Inherits: BuildingExplode
-	Warhead@2Eff: CreateEffect
-		Explosions: building, building_napalm, large_explosion, self_destruct
-
 CivBuildingExplosion:
-	Inherits: SmallBuildingExplode
+	Inherits: BuildingExplode
 	Warhead@1Dam: SpreadDamage # Used to panic civilians which are emitted from a killed CivBuilding
 		Spread: 64
 		Damage: 1

--- a/mods/raclassic/weapons/missiles.yaml
+++ b/mods/raclassic/weapons/missiles.yaml
@@ -284,7 +284,7 @@ TorpTube:
 			Concrete: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
-		Explosions: artillery_explosion
+		Explosions: building
 		ImpactSounds: kaboom15.aud
 	Warhead@4EffWater: CreateEffect
 		Explosions: large_splash
@@ -339,7 +339,7 @@ SCUD:
 			Concrete: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath, Incendiary
 	Warhead@3Eff: CreateEffect
-		Explosions: napalm
+		Explosions: building
 		ImpactSounds: firebl3.aud
 	Warhead@4EffWater: CreateEffect
 		Explosions: large_splash


### PR DESCRIPTION
It was called `building` appearantly in OpenRA, i didn't change the name.

This makes buildings only use this anim on death, also changes Artillery, V2, Crusier and Missile Sub's weapons to use it.