### PR TITLE
Some mostly small adjustments

### DIFF
--- a/mods/raclassic/rules/aircraft.yaml
+++ b/mods/raclassic/rules/aircraft.yaml
@@ -239,10 +239,10 @@ HELI:
 		Type: Heavy
 	Armament@PRIMARY:
 		Weapon: HellfireAA
-		LocalOffset: 0,-213,-85
+		LocalOffset: 0,-213,-85, 0,213,-85
 	Armament@SECONDARY:
 		Weapon: HellfireAG
-		LocalOffset: 0,213,-85
+		LocalOffset: 0,-213,-85, 0,213,-85
 	AttackHeli:
 		FacingTolerance: 20
 	Aircraft:

--- a/mods/raclassic/rules/campaign-palettes.yaml
+++ b/mods/raclassic/rules/campaign-palettes.yaml
@@ -1,6 +1,5 @@
 ^Palettes:
 	-PlayerColorPalette:
-	-PaletteFromPlayerPaletteWithAlpha@cloak:
 	IndexedPlayerPalette:
 		BasePalette: player
 		BaseName: player
@@ -16,7 +15,3 @@
 			Turkey: 200, 200, 201, 202, 203, 203, 204, 205, 206, 206, 207, 221, 222, 222, 223, 223
 			Neutral: 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143
 			Creeps: 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143
-	PaletteFromPlayerPaletteWithAlpha@Cloak:
-		BaseName: cloak
-		BasePalette: player
-		Alpha: 0.55

--- a/mods/raclassic/rules/defaults.yaml
+++ b/mods/raclassic/rules/defaults.yaml
@@ -58,11 +58,11 @@
 	AutoTargetPriority@DEFAULT:
 		RequiresCondition: !stance-attackanything
 		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Defense
-		InvalidTargets: NoAutoTarget, WaterStructure
+		InvalidTargets: NoAutoTarget, WaterStructure, Spy
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything
 		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Structure, Defense
-		InvalidTargets: NoAutoTarget
+		InvalidTargets: NoAutoTarget, Spy
 
 ^AutoTargetGroundAssaultMove:
 	Inherits: ^AutoTargetGround
@@ -85,11 +85,11 @@
 	AutoTargetPriority@DEFAULT:
 		RequiresCondition: !stance-attackanything
 		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Air, Defense
-		InvalidTargets: NoAutoTarget, WaterStructure
+		InvalidTargets: NoAutoTarget, WaterStructure, Spy
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything
 		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Air, Structure, Defense
-		InvalidTargets: NoAutoTarget
+		InvalidTargets: NoAutoTarget, Spy
 
 ^AutoTargetAllAssaultMove:
 	Inherits: ^AutoTargetAll
@@ -228,7 +228,7 @@
 	Selectable:
 		Bounds: 12,18,0,-8
 	Targetable:
-		TargetTypes: Ground, Infantry, Disguise
+		TargetTypes: Ground, Infantry
 		RequiresCondition: !parachute
 	QuantizeFacingsFromSequence:
 		Sequence: stand

--- a/mods/raclassic/rules/infantry.yaml
+++ b/mods/raclassic/rules/infantry.yaml
@@ -35,13 +35,10 @@ DOG:
 	AutoTarget:
 		InitialStance: AttackAnything
 	AutoTargetPriority@DEFAULT:
-		Types: Infantry
-	Targetable:
-		TargetTypes: Ground, Infantry
+		ValidTargets: Infantry, Spy
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 		StandSequences: stand
-	IgnoresDisguise:
 	Voiced:
 		VoiceSet: DogVoice
 	-TakeCover:
@@ -183,53 +180,27 @@ E6:
 
 SPY:
 	Inherits: ^Soldier
-	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 90
 		Prerequisites: dome, ~tent, ~techlevel.4
-		Description: Infiltrates enemy structures for intel or\nsabotage. Exact effect depends on the\nbuilding infiltrated.\nLoses disguise when attacking.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft\n  Special Ability: Disguised
+		Description: Infiltrates enemy structures for intel.\nExact effect depends on the building infiltrated.
 	Valued:
 		Cost: 500
-	-Tooltip:
-	DisguiseTooltip:
+	Tooltip:
 		Name: Spy
-		GenericName: Soldier
-	-Guard:
 	RevealsShroud:
 		Range: 5c0
 	Passenger:
 		PipType: Yellow
 		Voice: Move
-	Disguise:
-		Voice: Move
-		DisguisedCondition: disguise
 	Infiltrates:
 		Types: SpyInfiltrate
 		PlayerExperience: 50
-	AutoTarget:
-		InitialStance: HoldFire
-		InitialStanceAI: HoldFire
-		ScanRadius: 5
-	-WithInfantryBody:
-	WithDisguisingInfantryBody:
-		DefaultAttackSequence: shoot
-		IdleSequences: idle1,idle2
-		StandSequences: stand,stand2
-	WithDecoration@disguise:
-		Image: pips
-		Sequence: pip-disguise
-		Palette: effect
-		ReferencePoint: Top, Right
-		ZOffset: 256
-		RequiresCondition: disguise
-	IgnoresDisguise:
-	Armament:
-		Weapon: SilencedPPK
-	AttackFrontal:
-	AttackMove:
-		Voice: Move
+	WithInfantryBody:
+	Targetable:
+		TargetTypes: Ground, Infantry, Spy
 	Voiced:
 		VoiceSet: SpyVoice
 
@@ -309,7 +280,7 @@ MEDI:
 		VoiceSet: MedicVoice
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		Types: Infantry
+		ValidTargets: Infantry
 
 MECH:
 	Inherits: ^Soldier
@@ -347,7 +318,7 @@ MECH:
 		VoiceSet: MechanicVoice
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		Types: Vehicle
+		ValidTargets: Vehicle
 
 EINSTEIN:
 	Inherits: ^CivInfantry

--- a/mods/raclassic/rules/palettes.yaml
+++ b/mods/raclassic/rules/palettes.yaml
@@ -26,8 +26,8 @@
 		G: 0
 		B: 0
 		A: 140
-	PaletteFromRGBA@submerged:
-		Name: submerged
+	PaletteFromRGBA@cloak:
+		Name: cloak
 		R: 0
 		G: 0
 		B: 0
@@ -71,10 +71,6 @@
 	PlayerColorPalette:
 		BasePalette: player
 		RemapIndex: 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95
-	PaletteFromPlayerPaletteWithAlpha@cloak:
-		BaseName: cloak
-		BasePalette: player
-		Alpha: 0.55
 	PlayerHighlightPalette:
 	MenuPaletteEffect:
 	RotationPaletteEffect@defaultwater:

--- a/mods/raclassic/rules/ships.yaml
+++ b/mods/raclassic/rules/ships.yaml
@@ -238,8 +238,6 @@ LST:
 	Mobile:
 		TurnSpeed: 10
 		Speed: 113
-		TerrainSpeeds:
-			Beach: 70
 		RequiresCondition: !notmobile
 	RevealsShroud:
 		Range: 6c0

--- a/mods/raclassic/rules/ships.yaml
+++ b/mods/raclassic/rules/ships.yaml
@@ -33,7 +33,6 @@ SS:
 		CloakSound: subshow1.aud
 		UncloakSound: subshow1.aud
 		CloakedCondition: underwater
-		Palette: submerged
 		RequiresCondition: !cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
@@ -96,7 +95,6 @@ MSUB:
 		CloakSound: subshow1.aud
 		UncloakSound: subshow1.aud
 		CloakedCondition: underwater
-		Palette: submerged
 		RequiresCondition: !cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled

--- a/mods/raclassic/rules/ships.yaml
+++ b/mods/raclassic/rules/ships.yaml
@@ -68,7 +68,7 @@ MSUB:
 		BuildAtProductionType: Submarine
 		BuildPaletteOrder: 60
 		Prerequisites: ~spen, stek, ~disabled, ~techlevel.6
-		Description: Submerged anti-ground siege unit\nwith anti-air capabilities.\nCan detect other submarines.\n  Strong vs Buildings, Ground units, Aircraft\n  Weak vs Naval units\n  Special Ability: Submerge
+		Description: Submerged anti-ground siege unit.\nCan detect other submarines.\n  Strong vs Buildings, Ground units, Aircraft\n  Weak vs Naval units\n  Special Ability: Submerge
 	Valued:
 		Cost: 1650
 	Tooltip:
@@ -99,12 +99,8 @@ MSUB:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
-	Armament@PRIMARY:
-		Weapon: SubMissile
-		LocalOffset: 0,-171,0, 0,171,0
-		FireDelay: 2
-	Armament@SECONDARY:
-		Weapon: SubMissileAA
+	Armament:
+		Weapon: SubSCUD
 		LocalOffset: 0,-171,0, 0,171,0
 		FireDelay: 2
 	AttackFrontal:

--- a/mods/raclassic/rules/ships.yaml
+++ b/mods/raclassic/rules/ships.yaml
@@ -213,6 +213,7 @@ CA:
 		LocalOffset: 480,-100,40, 480,100,40
 		Recoil: 171
 		RecoilRecovery: 34
+		FireDelay: 5
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:

--- a/mods/raclassic/rules/structures.yaml
+++ b/mods/raclassic/rules/structures.yaml
@@ -719,7 +719,6 @@ WEAP:
 		Sequence: build-top
 	RallyPoint:
 	Exit@1:
-		SpawnOffset: 213,-128,0
 		ExitCell: 1,2
 	Production:
 		Produces: Vehicle

--- a/mods/raclassic/rules/vehicles.yaml
+++ b/mods/raclassic/rules/vehicles.yaml
@@ -487,15 +487,14 @@ TTNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 170
-		Prerequisites: tsla, ~disabled, ~techlevel.5
-		BuildDuration: 1166
+		Prerequisites: ~vehicle.soviet, tsla, ~disabled, ~techlevel.5
 		Description: Tank with mounted tesla coil.\n  Strong vs Infantry, Vehicles, Buildings\n  Weak vs Aircraft
 	Valued:
-		Cost: 1350
+		Cost: 1500
 	Tooltip:
 		Name: Tesla Tank
 	Health:
-		HP: 450
+		HP: 110
 	Armor:
 		Type: Light
 	Mobile:
@@ -503,9 +502,6 @@ TTNK:
 		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 7c0
-		RevealGeneratedShroud: False
-	RevealsShroud@GAPGEN:
-		Range: 6c0
 	Armament:
 		Weapon: TTankZap
 		LocalOffset: 0,0,213
@@ -524,17 +520,17 @@ DTRK:
 		Prerequisites: mslo, ~disabled, ~techlevel.10
 		Description: Demolition Truck, actively armed with\nnuclear explosives. Has very weak armor.
 	Valued:
-		Cost: 2500
+		Cost: 2400
 	Tooltip:
 		Name: Demolition Truck
 	Health:
-		HP: 50
+		HP: 110
 	Armor:
 		Type: Light
 	Mobile:
 		Speed: 85
 	RevealsShroud:
-		Range: 4c0
+		Range: 3c0
 	Explodes:
 		Weapon: MiniNuke
 		EmptyWeapon: MiniNuke
@@ -551,27 +547,23 @@ CTNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 200
-		Prerequisites: atek, ~disabled, ~techlevel.9
-		BuildDuration: 1166
+		Prerequisites: ~vehicle.allies, atek, ~disabled, ~techlevel.9
 		Description: Chrono Tank, teleports to areas within range.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft\n  Special ability: Can teleport
 	Valued:
-		Cost: 1350
+		Cost: 2400
 	Tooltip:
 		Name: Chrono Tank
 	SelectionDecorations:
 		VisualBounds: 30,30
 	Health:
-		HP: 450
+		HP: 350
 	Armor:
 		Type: Light
 	Mobile:
 		Speed: 113
 		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
-		Range: 6c0
-		RevealGeneratedShroud: False
-	RevealsShroud@GAPGEN:
-		Range: 4c0
+		Range: 5c0
 	Armament@PRIMARY:
 		Weapon: APTusk
 		LocalOffset: -160,-276,232
@@ -589,14 +581,14 @@ QTNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 190
-		Prerequisites: stek, ~disabled, ~techlevel.7
+		Prerequisites: ~vehicle.soviet, stek, ~disabled, ~techlevel.7
 		Description: Deals seismic damage to nearby vehicles\nand structures.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft
 	Valued:
-		Cost: 2000
+		Cost: 2300
 	Tooltip:
 		Name: MAD Tank
 	Health:
-		HP: 900
+		HP: 300
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -604,9 +596,6 @@ QTNK:
 		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 6c0
-		RevealGeneratedShroud: False
-	RevealsShroud@GAPGEN:
-		Range: 4c0
 	SelectionDecorations:
 		VisualBounds: 44,38,0,-4
 	MadTank:
@@ -619,26 +608,22 @@ STNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 130
-		Prerequisites: atek, ~disabled
-		BuildDuration: 1166
-		Description: Lightly armored infantry transport\nwhich can cloak. Can detect cloaked units.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
+		Prerequisites: ~vehicle.allies, atek, ~disabled
+		Description: Lightly armored infantry transport\nwhich can cloak.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
 	Valued:
-		Cost: 1350
+		Cost: 800
 	Tooltip:
 		Name: Phase Transport
 	Health:
-		HP: 300
+		HP: 200
 	Armor:
-		Type: Light
+		Type: Heavy
 	Mobile:
 		Speed: 142
 		Crushes: wall, mine, crate, infantry
 		RequiresCondition: !notmobile
 	RevealsShroud:
-		Range: 7c0
-		RevealGeneratedShroud: False
-	RevealsShroud@GAPGEN:
-		Range: 4c0
+		Range: 5c0
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire
@@ -651,8 +636,8 @@ STNK:
 	WithSpriteTurret:
 	Cargo:
 		Types: Infantry
-		MaxWeight: 4
-		PipCount: 4
+		MaxWeight: 1
+		PipCount: 1
 		LoadingCondition: notmobile
 	Cloak:
 		InitialDelay: 0
@@ -663,6 +648,4 @@ STNK:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
-	DetectCloaked:
-		Range: 7c0
 	-MustBeDestroyed:

--- a/mods/raclassic/rules/vehicles.yaml
+++ b/mods/raclassic/rules/vehicles.yaml
@@ -655,11 +655,10 @@ STNK:
 		PipCount: 4
 		LoadingCondition: notmobile
 	Cloak:
-		InitialDelay: 125
+		InitialDelay: 0
 		CloakDelay: 250
 		CloakSound: appear1.aud
 		UncloakSound: appear1.aud
-		IsPlayerPalette: true
 		RequiresCondition: !cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled

--- a/mods/raclassic/weapons/ballistics.yaml
+++ b/mods/raclassic/weapons/ballistics.yaml
@@ -112,7 +112,6 @@ TurretGun:
 	Inherits: ^Artillery
 	ReloadDelay: 160
 	Range: 22c0
-	Burst: 2
 	Report: turret1.aud
 	TargetActorCenter: true
 	Projectile: Bullet
@@ -120,7 +119,7 @@ TurretGun:
 		ContrailLength: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 25
+		Damage: 50
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 90

--- a/mods/raclassic/weapons/ballistics.yaml
+++ b/mods/raclassic/weapons/ballistics.yaml
@@ -84,7 +84,6 @@ TurretGun:
 		Speed: 204
 		Blockable: false
 		LaunchAngle: 62
-		Inaccuracy: 1c938
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 150
@@ -105,8 +104,6 @@ TurretGun:
 	Inherits: ^Artillery
 	Report: tank5.aud
 	TargetActorCenter: true
-	Projectile: Bullet
-		ContrailLength: 30
 
 8Inch:
 	Inherits: ^Artillery
@@ -116,7 +113,6 @@ TurretGun:
 	TargetActorCenter: true
 	Projectile: Bullet
 		Inaccuracy: 2c938
-		ContrailLength: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 50

--- a/mods/raclassic/weapons/missiles.yaml
+++ b/mods/raclassic/weapons/missiles.yaml
@@ -7,8 +7,9 @@
 		Speed: 213
 		Arm: 2
 		Blockable: false
-		ContrailLength: 10
 		Inaccuracy: 128
+		TrailImage: smokey
+		TrailInterval: 1
 		Image: DRAGON
 		Shadow: True
 		HorizontalRateOfTurn: 5
@@ -66,8 +67,6 @@ Maverick:
 
 Dragon:
 	Inherits: ^AntiGroundMissile
-	Projectile: Missile
-		TrailImage: smokey
 
 HellfireAG:
 	Inherits: ^AntiGroundMissile
@@ -127,6 +126,7 @@ MammothTusk:
 			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
+		Explosions: artillery_explosion
 		ImpactSounds: kaboom12.aud
 		ValidTargets: Ground, Trees
 	Warhead@5EffAir: CreateEffect
@@ -205,19 +205,21 @@ StingerAA:
 
 APTusk:
 	Inherits: ^AntiGroundMissile
-	ReloadDelay: 60
-	Range: 6c0
+	ReloadDelay: 80
+	Range: 5c0
 	Projectile: Missile
 		Speed: 298
-		TrailImage: smokey
 		HorizontalRateOfTurn: 10
 		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
-		Damage: 30
+		Damage: 75
 		Versus:
-			None: 25
+			None: 30
+			Wood: 75
 			Light: 75
 			Concrete: 50
+	Warhead@3Eff: CreateEffect
+		Explosions: building
 
 TorpTube:
 	ReloadDelay: 100
@@ -258,29 +260,30 @@ TorpTube:
 		ValidTargets: Water
 		InvalidTargets: Ship, Structure, Underwater, Bridge
 
-^SubMissileDefault:
+SubSCUD:
 	Inherits: ^AntiGroundMissile
-	ReloadDelay: 300
-	Range: 8c0
+	ReloadDelay: 120
+	Range: 14c0
+	TargetActorCenter: true
 	Burst: 2
 	Projectile: Missile
 		Speed: 234
 		Inaccuracy: 0c614
-		HorizontalRateOfTurn: 15
-		RangeLimit: 9c0
+		HorizontalRateOfTurn: 5
+		RangeLimit: 15c0
 		LaunchAngle: 120
 		Image: MISSILE
 		TrailImage: smokey
-		ContrailLength: 30
+		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 25
+		Damage: 40
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
-			None: 40
-			Wood: 40
-			Light: 30
-			Heavy: 30
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
 			Concrete: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
@@ -289,27 +292,6 @@ TorpTube:
 	Warhead@4EffWater: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
-
-SubMissile:
-	Inherits: ^SubMissileDefault
-	Range: 16c0
-	TargetActorCenter: true
-	-Projectile:
-	Projectile: Bullet
-		Speed: 162
-		Blockable: false
-		LaunchAngle: 120
-		Inaccuracy: 2c938
-		Image: MISSILE
-		Shadow: True
-		TrailImage: smokey
-		ContrailLength: 30
-
-SubMissileAA:
-	Inherits: ^SubMissileDefault
-	ValidTargets: Air
-	Warhead@1Dam: SpreadDamage
-		Damage: 15
 
 SCUD:
 	Inherits: ^AntiGroundMissile
@@ -323,6 +305,7 @@ SCUD:
 		Blockable: false
 		TrailImage: smokey
 		TrailDelay: 5
+		TrailInterval: 1
 		Inaccuracy: 213
 		Image: V2
 		Shadow: True

--- a/mods/raclassic/weapons/superweapons.yaml
+++ b/mods/raclassic/weapons/superweapons.yaml
@@ -1,6 +1,6 @@
 ParaBomb:
 	ReloadDelay: 10
-	Range: 3c0
+	Range: 4c512
 	Report: chute1.aud
 	Projectile: GravityBomb
 		Image: PARABOMB
@@ -12,16 +12,17 @@ ParaBomb:
 		Spread: 768
 		Damage: 300
 		Versus:
-			None: 30
-			Wood: 30
-			Light: 75
-			Concrete: 25
+			None: 90
+			Wood: 75
+			Light: 60
+			Heavy: 25
+			Concrete: 100
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
 	Warhead@3Eff: CreateEffect
-		Explosions: artillery_explosion
+		Explosions: building
 		ImpactSounds: kaboom15.aud
 		ValidTargets: Ground, Ship, Trees
 	Warhead@4EffWater: CreateEffect
@@ -38,15 +39,17 @@ Atomic:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Trees, Water, Underwater, Air
 		Versus:
-			Wood: 25
-			Concrete: 25
+			None: 90
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Res_impact: DestroyResource
 		Size: 1
 	Warhead@3Smu_impact: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Tank, Structure, Wall
-		Size: 1
+		Size: 0
 	Warhead@4Eff_impact: CreateEffect
 		Explosions: nuke
 		ImpactSounds: kaboom1.aud
@@ -59,16 +62,18 @@ Atomic:
 		Delay: 5
 		ValidTargets: Ground, Trees, Water, Underwater, Air
 		Versus:
-			Wood: 25
-			Concrete: 25
+			None: 90
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@6Res_areanuke1: DestroyResource
-		Size: 2
+		Size: 2, 2
 		Delay: 5
 	Warhead@7Smu_areanuke1: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
-		Size: 2
+		Size: 2, 2
 		Delay: 5
 	Warhead@8Eff_areanuke1: CreateEffect
 		ImpactSounds: kaboom22.aud
@@ -81,8 +86,10 @@ Atomic:
 		Delay: 10
 		ValidTargets: Ground, Water, Underwater, Air
 		Versus:
-			Wood: 50
-			Concrete: 25
+			None: 90
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@10Dam_areanuke2: SpreadDamage
 		Spread: 3c0
@@ -92,12 +99,12 @@ Atomic:
 		ValidTargets: Trees
 		DamageTypes: Incendiary
 	Warhead@11Res_areanuke2: DestroyResource
-		Size: 3
+		Size: 3, 3
 		Delay: 10
 	Warhead@12Smu_areanuke2: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
-		Size: 3
+		Size: 3, 3
 		Delay: 10
 	Warhead@13Dam_areanuke3: SpreadDamage
 		Spread: 4c0
@@ -106,7 +113,10 @@ Atomic:
 		Delay: 15
 		ValidTargets: Ground, Water, Underwater, Air
 		Versus:
-			Concrete: 25
+			None: 90
+			Light: 60
+			Heavy: 25
+			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@14Dam_areanuke3: SpreadDamage
 		Spread: 4c0
@@ -116,34 +126,10 @@ Atomic:
 		ValidTargets: Trees
 		DamageTypes: Incendiary
 	Warhead@15Res_areanuke3: DestroyResource
-		Size: 4
+		Size: 4, 4
 		Delay: 15
 	Warhead@16Smu_areanuke3: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
-		Size: 4
+		Size: 4, 4
 		Delay: 15
-	Warhead@17Dam_areanuke4: SpreadDamage
-		Spread: 5c0
-		Damage: 60
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		Delay: 20
-		ValidTargets: Ground, Water, Underwater, Air
-		Versus:
-			Concrete: 25
-		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@18Dam_areanuke4: SpreadDamage
-		Spread: 5c0
-		Damage: 120
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		Delay: 20
-		ValidTargets: Trees
-		DamageTypes: Incendiary
-	Warhead@19Res_areanuke4: DestroyResource
-		Size: 5
-		Delay: 20
-	Warhead@20Smu_areanuke4: LeaveSmudge
-		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
-		Size: 5
-		Delay: 20


### PR DESCRIPTION
I have done some stuff while i was alone with no internet:

- Spy disguise logic removed. Currently no units but dogs AutoTarget them. You can (and AI do too) still manually target them. Still not the same as original, but i think closer.
- Spy weapon is removed.
- Removed contrails from missiles.
- Adjusted some values for Aftermath units. Removed Missile Sub AA.
- Units now leave War Factory directly to south as in original, instead of with a wierd angle.