### PR TITLE
Make Heal weapons use InstantHit Proj and TargetDamage Warhead

### DIFF
--- a/mods/raclassic/weapons/other.yaml
+++ b/mods/raclassic/weapons/other.yaml
@@ -96,10 +96,9 @@ Heal:
 	Range: 1c849
 	Report: heal2.aud
 	ValidTargets: Infantry
-	Projectile: Bullet
-		Speed: 1c682
-	Warhead@1Dam: SpreadDamage
-		Spread: 32
+	TargetActorCenter: true
+	Projectile: InstantHit
+	Warhead@1Dam: TargetDamage
 		Damage: -50
 		ValidStances: Ally
 		ValidTargets: Infantry


### PR DESCRIPTION
Speed = 100 means instant hit original. Some other weapons also use it, but i'll edit them with another PR.

Similarly Spread = 0 means only damage the target, which is what our TargetDamage Warhead does. No need to mess with too small Spread values.

Without `TargetActorCenter: true` medic didn't work, while mechanic does, not sure what exactly is the reason. Also looks like TS Mod also uses these for medic: https://github.com/OpenRA/OpenRA/blob/bleed/mods/ts/weapons/healweapons.yaml