### PR TITLE
Iron Curtain charge time/duration fix

### DIFF
--- a/mods/raclassic/rules/structures.yaml
+++ b/mods/raclassic/rules/structures.yaml
@@ -277,11 +277,11 @@ IRON:
 		Range: 10c0
 	GrantExternalConditionPower@IRONCURTAIN:
 		Icon: invuln
-		ChargeTime: 660
+		ChargeTime: 300
 		Description: Invulnerability
 		LongDesc: Makes a unit invulnerable\nfor 45 seconds.
 		Range: 0
-		Duration: 300
+		Duration: 1125
 		SelectTargetSpeechNotification: SelectTarget
 		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: IronCurtainCharging


### PR DESCRIPTION
#56 updated the duration of the iron curtain instead of charge time, this restores the 45 seconds duration and sets 5 minute cooldown