### PR TITLE
Removed MECH repair for STNK while cloaked

### DIFF
--- a/mods/raclassic/rules/vehicles.yaml
+++ b/mods/raclassic/rules/vehicles.yaml
@@ -624,6 +624,11 @@ STNK:
 		HP: 200
 	Armor:
 		Type: Heavy
+	Targetable:
+		RequiresCondition: !parachute && !cloaked
+	Targetable@CLOAKED:
+		TargetTypes: Ground, Vehicle
+		RequiresCondition: !parachute && cloaked
 	Mobile:
 		Speed: 142
 		RequiresCondition: !notmobile
@@ -649,6 +654,7 @@ STNK:
 		CloakDelay: 250
 		CloakSound: appear1.aud
 		UncloakSound: appear1.aud
+		CloakedCondition: cloaked
 		RequiresCondition: !cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled


### PR DESCRIPTION
The phase transport could not be repaired by mechanics while cloaked in the original game.