### PR TITLE
Add Countries

### DIFF
--- a/mods/raclassic/audio/voices.yaml
+++ b/mods/raclassic/audio/voices.yaml
@@ -4,6 +4,9 @@ GenericVoice:
 		england: .v01,.v03
 		france: .v01,.v03
 		germany: .v01,.v03
+		spain: .v01,.v03
+		greece: .v01,.v03
+		turkey: .v01,.v03
 		soviet: .r01,.r03
 		russia: .r01,.r03
 		ukraine: .r01,.r03
@@ -21,6 +24,9 @@ VehicleVoice:
 		england: .v00,.v02
 		france: .v00,.v02
 		germany: .v00,.v02
+		spain: .v00,.v02
+		greece: .v00,.v02
+		turkey: .v00,.v02
 		soviet: .r00,.r02
 		russia: .r00,.r02
 		ukraine: .r00,.r02

--- a/mods/raclassic/metrics.yaml
+++ b/mods/raclassic/metrics.yaml
@@ -7,6 +7,9 @@ Metrics:
 	FactionSuffix-england: allies
 	FactionSuffix-france: allies
 	FactionSuffix-germany: allies
+	FactionSuffix-spain: allies
+	FactionSuffix-greece: allies
+	FactionSuffix-turkey: allies
 	FactionSuffix-russia: soviet
 	FactionSuffix-soviet: soviet
 	FactionSuffix-ukraine: soviet

--- a/mods/raclassic/mod.yaml
+++ b/mods/raclassic/mod.yaml
@@ -53,6 +53,7 @@ Rules:
 	raclassic|rules/aircraft.yaml
 	raclassic|rules/ships.yaml
 	raclassic|rules/fakes.yaml
+	raclassic|rules/country-duplicates.yaml
 
 Sequences:
 	raclassic|sequences/ships.yaml

--- a/mods/raclassic/rules/ai.yaml
+++ b/mods/raclassic/rules/ai.yaml
@@ -5,15 +5,15 @@ Player:
 		MinimumExcessPower: 40
 		BuildingCommonNames:
 			ConstructionYard: fact
-			Refinery: proc
-			Power: powr,apwr
-			Barracks: barr,tent
-			VehiclesFactory: weap
-			Production: barr,tent,weap
-			Silo: silo
+			Refinery: proc, proc.russia, proc.turkey
+			Power: powr, powr.russia, powr.greece, powr.turkey, apwr, apwr.russia, apwr.greece, apwr.turkey
+			Barracks: barr, barr.russia, barr.turkey, tent.russia, tent.turkey
+			VehiclesFactory: weap, weap.russia, weap.turkey
+			Production: barr, barr.russia, barr.turkey, tent.russia, tent.turkey, weap, weap.russia, weap.turkey
+			Silo: silo, silo.russia, silo.turkey
 		UnitsCommonNames:
-			Mcv: mcv
-			NavalUnits: ss,msub,dd,ca,lst,pt
+			Mcv: mcv, mcv.russia, mcv.turkey
+			NavalUnits: ss, ss.russia, ss.turkey, msub, msub.russia, msub.turkey, dd, dd.russia, dd.turkey, ca.russia, ca.turkey, lst.russia, lst.turkey, pt.russia, pt.turkey
 		BuildingLimits:
 			proc: 4
 			barr: 1
@@ -24,6 +24,24 @@ Player:
 			atek: 1
 			stek: 1
 			fix: 1
+			proc.russia: 4
+			barr.russia: 1
+			tent.russia: 1
+			kenn.russia: 1
+			dome.russia: 1
+			weap.russia: 1
+			atek.russia: 1
+			stek.russia: 1
+			fix.russia: 1
+			proc.turkey: 4
+			barr.turkey: 1
+			tent.turkey: 1
+			kenn.turkey: 1
+			dome.turkey: 1
+			weap.turkey: 1
+			atek.turkey: 1
+			stek.turkey: 1
+			fix.turkey: 1
 		BuildingFractions:
 			proc: 30%
 			powr: 15%
@@ -43,6 +61,44 @@ Player:
 			stek: 1%
 			fix: 0.1%
 			dome: 10%
+			proc.russia: 30%
+			powr.russia: 15%
+			apwr.russia: 20%
+			barr.russia: 1%
+			kenn.russia: 0.5%
+			tent.russia: 1%
+			weap.russia: 1%
+			pbox.russia: 7%
+			gun.russia: 7%
+			tsla.russia: 5%
+			gap.russia: 2%
+			ftur.russia: 10%
+			agun.russia: 5%
+			sam.russia: 5%
+			atek.russia: 1%
+			stek.russia: 1%
+			fix.russia: 0.1%
+			dome.russia: 10%
+			powr.greece: 15%
+			apwr.greece: 20%
+			proc.turkey: 30%
+			powr.turkey: 15%
+			apwr.turkey: 20%
+			barr.turkey: 1%
+			kenn.turkey: 0.5%
+			tent.turkey: 1%
+			weap.turkey: 1%
+			pbox.turkey: 7%
+			gun.turkey: 7%
+			tsla.turkey: 5%
+			gap.turkey: 2%
+			ftur.turkey: 10%
+			agun.turkey: 5%
+			sam.turkey: 5%
+			atek.turkey: 1%
+			stek.turkey: 1%
+			fix.turkey: 0.1%
+			dome.turkey: 10%
 		UnitsToBuild:
 			e1: 65%
 			e2: 25%
@@ -61,9 +117,47 @@ Player:
 			4tnk: 10%
 			ttnk: 10%
 			stnk: 5%
+			e1.russia: 65%
+			e2.russia: 25%
+			e3.russia: 40%
+			e4.russia: 15%
+			dog.russia: 15%
+			shok.russia: 15%
+			harv.russia: 10%
+			apc.russia: 30%
+			jeep.russia: 40%
+			arty.russia: 15%
+			v2rl.russia: 40%
+			1tnk.russia: 70%
+			2tnk.russia: 25%
+			3tnk.russia: 50%
+			4tnk.russia: 10%
+			ttnk.russia: 10%
+			stnk.russia: 5%
+			e1.turkey: 65%
+			e2.turkey: 25%
+			e3.turkey: 40%
+			e4.turkey: 15%
+			dog.turkey: 15%
+			shok.turkey: 15%
+			harv.turkey: 10%
+			apc.turkey: 30%
+			jeep.turkey: 40%
+			arty.turkey: 15%
+			v2rl.turkey: 40%
+			1tnk.turkey: 70%
+			2tnk.turkey: 25%
+			3tnk.turkey: 50%
+			4tnk.turkey: 10%
+			ttnk.turkey: 10%
+			stnk.turkey: 5%
 		UnitLimits:
 			dog: 4
 			harv: 8
+			dog.russia: 4
+			harv.russia: 8
+			dog.turkey: 4
+			harv.turkey: 8
 		SquadSize: 20
 		SupportPowerDecision@spyplane:
 			OrderName: SovietSpyPlane
@@ -119,20 +213,21 @@ Player:
 		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact
-			Refinery: proc
-			Power: powr,apwr
-			Barracks: barr,tent
-			VehiclesFactory: weap
-			Production: barr,tent,weap,afld,hpad
-			NavalProduction: spen,syrd
-			Silo: silo
+			Refinery: proc, proc.russia, proc.turkey
+			Power: powr, powr.russia, powr.greece, powr.turkey, apwr, apwr.russia, apwr.greece, apwr.turkey
+			Barracks: barr, barr.russia, barr.turkey, tent.russia, tent.turkey
+			VehiclesFactory: weap, weap.russia, weap.turkey
+			Production: barr, barr.russia, barr.turkey, tent.russia, tent.turkey, weap, weap.russia, weap.turkey, afld, afld.russia, afld.turkey, hpad, hpad.russia, hpad.turkey
+			NavalProduction: spen, spen.russia, spen.turkey, syrd, syrd.russia, syrd.turkey
+			Silo: silo, silo.russia, silo.turkey
 		UnitsCommonNames:
-			Mcv: mcv
-			NavalUnits: ss,msub,dd,ca,lst,pt
+			Mcv: mcv, mcv.russia, mcv.turkey
+			NavalUnits: ss, ss.russia, ss.turkey, msub, msub.russia, msub.turkey, dd, dd.russia, dd.turkey, ca.russia, ca.turkey, lst.russia, lst.turkey, pt.russia, pt.turkey
 		BuildingLimits:
 			proc: 4
 			barr: 1
 			tent: 1
+			kenn: 1
 			dome: 1
 			weap: 1
 			spen: 1
@@ -142,6 +237,32 @@ Player:
 			atek: 1
 			stek: 1
 			fix: 1
+			proc.russia: 4
+			barr.russia: 1
+			tent.russia: 1
+			kenn.russia: 1
+			dome.russia: 1
+			weap.russia: 1
+			spen.russia: 1
+			syrd.russia: 1
+			hpad.russia: 4
+			afld.russia: 4
+			atek.russia: 1
+			stek.russia: 1
+			fix.russia: 1
+			proc.turkey: 4
+			barr.turkey: 1
+			tent.turkey: 1
+			kenn.turkey: 1
+			dome.turkey: 1
+			weap.turkey: 1
+			spen.turkey: 1
+			syrd.turkey: 1
+			hpad.turkey: 4
+			afld.turkey: 4
+			atek.turkey: 1
+			stek.turkey: 1
+			fix.turkey: 1
 		BuildingFractions:
 			proc: 10%
 			powr: 1%
@@ -166,6 +287,54 @@ Player:
 			atek: 1%
 			stek: 1%
 			mslo: 1%
+			proc.russia: 10%
+			powr.russia: 1%
+			apwr.russia: 30%
+			tent.russia: 1%
+			barr.russia: 1%
+			kenn.russia: 0.5%
+			dome.russia: 1%
+			weap.russia: 6%
+			hpad.russia: 4%
+			spen.russia: 1%
+			syrd.russia: 1%
+			afld.russia: 4%
+			pbox.russia: 7%
+			gun.russia: 7%
+			ftur.russia: 10%
+			tsla.russia: 5%
+			gap.russia: 2%
+			fix.russia: 1%
+			agun.russia: 5%
+			sam.russia: 1%
+			atek.russia: 1%
+			stek.russia: 1%
+			mslo.russia: 1%
+			powr.greece: 1%
+			apwr.greece: 30%
+			proc.turkey: 10%
+			powr.turkey: 1%
+			apwr.turkey: 30%
+			tent.turkey: 1%
+			barr.turkey: 1%
+			kenn.turkey: 0.5%
+			dome.turkey: 1%
+			weap.turkey: 6%
+			hpad.turkey: 4%
+			spen.turkey: 1%
+			syrd.turkey: 1%
+			afld.turkey: 4%
+			pbox.turkey: 7%
+			gun.turkey: 7%
+			ftur.turkey: 10%
+			tsla.turkey: 5%
+			gap.turkey: 2%
+			fix.turkey: 1%
+			agun.turkey: 5%
+			sam.turkey: 1%
+			atek.turkey: 1%
+			stek.turkey: 1%
+			mslo.turkey: 1%
 		UnitsToBuild:
 			e1: 65%
 			e2: 25%
@@ -193,9 +362,65 @@ Player:
 			dd: 10%
 			ca: 10%
 			pt: 10%
+			e1.russia: 65%
+			e2.russia: 25%
+			e3.russia: 40%
+			e4.russia: 15%
+			dog.russia: 15%
+			shok.russia: 15%
+			harv.russia: 10%
+			apc.russia: 30%
+			jeep.russia: 40%
+			arty.russia: 15%
+			v2rl.russia: 40%
+			1tnk.russia: 70%
+			2tnk.russia: 25%
+			3tnk.russia: 50%
+			4tnk.russia: 15%
+			ttnk.russia: 15%
+			stnk.russia: 10%
+			heli.russia: 30%
+			hind.russia: 30%
+			mig.russia: 30%
+			yak.russia: 30%
+			ss.russia: 10%
+			msub.russia: 10%
+			dd.russia: 10%
+			ca.russia: 10%
+			pt.russia: 10%
+			e1.turkey: 65%
+			e2.turkey: 25%
+			e3.turkey: 40%
+			e4.turkey: 15%
+			dog.turkey: 15%
+			shok.turkey: 15%
+			harv.turkey: 10%
+			apc.turkey: 30%
+			jeep.turkey: 40%
+			arty.turkey: 15%
+			v2rl.turkey: 40%
+			1tnk.turkey: 70%
+			2tnk.turkey: 25%
+			3tnk.turkey: 50%
+			4tnk.turkey: 15%
+			ttnk.turkey: 15%
+			stnk.turkey: 10%
+			heli.turkey: 30%
+			hind.turkey: 30%
+			mig.turkey: 30%
+			yak.turkey: 30%
+			ss.turkey: 10%
+			msub.turkey: 10%
+			dd.turkey: 10%
+			ca.turkey: 10%
+			pt.turkey: 10%
 		UnitLimits:
 			dog: 4
 			harv: 8
+			dog.russia: 4
+			harv.russia: 8
+			dog.turkey: 4
+			harv.turkey: 8
 		SquadSize: 40
 		SupportPowerDecision@spyplane:
 			OrderName: SovietSpyPlane
@@ -251,16 +476,16 @@ Player:
 		MinimumExcessPower: 100
 		BuildingCommonNames:
 			ConstructionYard: fact
-			Refinery: proc
-			Power: powr,apwr
-			Barracks: barr,tent
-			VehiclesFactory: weap
-			Production: barr,tent,weap,afld,hpad
-			NavalProduction: spen,syrd
-			Silo: silo
+			Refinery: proc, proc.russia, proc.turkey
+			Power: powr, powr.russia, powr.greece, powr.turkey, apwr, apwr.russia, apwr.greece, apwr.turkey
+			Barracks: barr, barr.russia, barr.turkey, tent.russia, tent.turkey
+			VehiclesFactory: weap, weap.russia, weap.turkey
+			Production: barr, barr.russia, barr.turkey, tent.russia, tent.turkey, weap, weap.russia, weap.turkey, afld, afld.russia, afld.turkey, hpad, hpad.russia, hpad.turkey
+			NavalProduction: spen, spen.russia, spen.turkey, syrd, syrd.russia, syrd.turkey
+			Silo: silo, silo.russia, silo.turkey
 		UnitsCommonNames:
-			Mcv: mcv
-			NavalUnits: ss,msub,dd,ca,lst,pt
+			Mcv: mcv, mcv.russia, mcv.turkey
+			NavalUnits: ss, ss.russia, ss.turkey, msub, msub.russia, msub.turkey, dd, dd.russia, dd.turkey, ca.russia, ca.turkey, lst.russia, lst.turkey, pt.russia, pt.turkey
 		BuildingLimits:
 			proc: 4
 			barr: 1
@@ -275,6 +500,32 @@ Player:
 			atek: 1
 			stek: 1
 			fix: 1
+			proc.russia: 4
+			barr.russia: 1
+			tent.russia: 1
+			kenn.russia: 1
+			dome.russia: 1
+			weap.russia: 1
+			spen.russia: 1
+			syrd.russia: 1
+			hpad.russia: 4
+			afld.russia: 4
+			atek.russia: 1
+			stek.russia: 1
+			fix.russia: 1
+			proc.turkey: 4
+			barr.turkey: 1
+			tent.turkey: 1
+			kenn.turkey: 1
+			dome.turkey: 1
+			weap.turkey: 1
+			spen.turkey: 1
+			syrd.turkey: 1
+			hpad.turkey: 4
+			afld.turkey: 4
+			atek.turkey: 1
+			stek.turkey: 1
+			fix.turkey: 1
 		BuildingFractions:
 			proc: 30%
 			powr: 1%
@@ -298,6 +549,52 @@ Player:
 			atek: 1%
 			stek: 1%
 			mslo: 1%
+			proc.russia: 30%
+			powr.russia: 1%
+			apwr.russia: 20%
+			tent.russia: 1%
+			barr.russia: 1%
+			kenn.russia: 0.5%
+			weap.russia: 3%
+			hpad.russia: 2%
+			spen.russia: 1%
+			syrd.russia: 1%
+			pbox.russia: 10%
+			gun.russia: 10%
+			ftur.russia: 10%
+			tsla.russia: 7%
+			gap.russia: 3%
+			fix.russia: 0.1%
+			dome.russia: 10%
+			agun.russia: 5%
+			sam.russia: 5%
+			atek.russia: 1%
+			stek.russia: 1%
+			mslo.russia: 1%
+			powr.greece: 1%
+			apwr.greece: 20%
+			proc.turkey: 30%
+			powr.turkey: 1%
+			apwr.turkey: 20%
+			tent.turkey: 1%
+			barr.turkey: 1%
+			kenn.turkey: 0.5%
+			weap.turkey: 3%
+			hpad.turkey: 2%
+			spen.turkey: 1%
+			syrd.turkey: 1%
+			pbox.turkey: 10%
+			gun.turkey: 10%
+			ftur.turkey: 10%
+			tsla.turkey: 7%
+			gap.turkey: 3%
+			fix.turkey: 0.1%
+			dome.turkey: 10%
+			agun.turkey: 5%
+			sam.turkey: 5%
+			atek.turkey: 1%
+			stek.turkey: 1%
+			mslo.turkey: 1%
 		UnitsToBuild:
 			e1: 65%
 			e2: 25%
@@ -325,9 +622,65 @@ Player:
 			dd: 10%
 			ca: 10%
 			pt: 10%
+			e1.russia: 65%
+			e2.russia: 25%
+			e3.russia: 40%
+			e4.russia: 15%
+			dog.russia: 15%
+			shok.russia: 15%
+			harv.russia: 10%
+			apc.russia: 30%
+			jeep.russia: 40%
+			arty.russia: 15%
+			v2rl.russia: 40%
+			1tnk.russia: 70%
+			2tnk.russia: 25%
+			3tnk.russia: 50%
+			4tnk.russia: 20%
+			ttnk.russia: 20%
+			stnk.russia: 15%
+			heli.russia: 30%
+			hind.russia: 30%
+			mig.russia: 30%
+			yak.russia: 30%
+			ss.russia: 10%
+			msub.russia: 10%
+			dd.russia: 10%
+			ca.russia: 10%
+			pt.russia: 10%
+			e1.turkey: 65%
+			e2.turkey: 25%
+			e3.turkey: 40%
+			e4.turkey: 15%
+			dog.turkey: 15%
+			shok.turkey: 15%
+			harv.turkey: 10%
+			apc.turkey: 30%
+			jeep.turkey: 40%
+			arty.turkey: 15%
+			v2rl.turkey: 40%
+			1tnk.turkey: 70%
+			2tnk.turkey: 25%
+			3tnk.turkey: 50%
+			4tnk.turkey: 20%
+			ttnk.turkey: 20%
+			stnk.turkey: 15%
+			heli.turkey: 30%
+			hind.turkey: 30%
+			mig.turkey: 30%
+			yak.turkey: 30%
+			ss.turkey: 10%
+			msub.turkey: 10%
+			dd.turkey: 10%
+			ca.turkey: 10%
+			pt.turkey: 10%
 		UnitLimits:
 			dog: 4
 			harv: 8
+			dog.russia: 4
+			harv.russia: 8
+			dog.turkey: 4
+			harv.turkey: 8
 		SquadSize: 10
 		SupportPowerDecision@spyplane:
 			OrderName: SovietSpyPlane
@@ -382,16 +735,16 @@ Player:
 		Type: naval
 		BuildingCommonNames:
 			ConstructionYard: fact
-			Refinery: proc
-			Power: powr,apwr
-			Barracks: barr,tent
-			VehiclesFactory: weap
-			Production: barr,tent,weap,afld,hpad
-			NavalProduction: spen,syrd
-			Silo: silo
+			Refinery: proc, proc.russia, proc.turkey
+			Power: powr, powr.russia, powr.greece, powr.turkey, apwr, apwr.russia, apwr.greece, apwr.turkey
+			Barracks: barr, barr.russia, barr.turkey, tent.russia, tent.turkey
+			VehiclesFactory: weap, weap.russia, weap.turkey
+			Production: barr, barr.russia, barr.turkey, tent.russia, tent.turkey, weap, weap.russia, weap.turkey, afld, afld.russia, afld.turkey, hpad, hpad.russia, hpad.turkey
+			NavalProduction: spen, spen.russia, spen.turkey, syrd, syrd.russia, syrd.turkey
+			Silo: silo, silo.russia, silo.turkey
 		UnitsCommonNames:
-			Mcv: mcv
-			NavalUnits: ss,msub,dd,ca,lst,pt
+			Mcv: mcv, mcv.russia, mcv.turkey
+			NavalUnits: ss, ss.russia, ss.turkey, msub, msub.russia, msub.turkey, dd, dd.russia, dd.turkey, ca.russia, ca.turkey, lst.russia, lst.turkey, pt.russia, pt.turkey
 		BuildingLimits:
 			proc: 4
 			dome: 1
@@ -405,6 +758,30 @@ Player:
 			atek: 1
 			stek: 1
 			fix: 1
+			proc.russia: 4
+			dome.russia: 1
+			barr.russia: 1
+			tent.russia: 1
+			spen.russia: 1
+			syrd.russia: 1
+			hpad.russia: 4
+			afld.russia: 4
+			weap.russia: 1
+			atek.russia: 1
+			stek.russia: 1
+			fix.russia: 1
+			proc.turkey: 4
+			dome.turkey: 1
+			barr.turkey: 1
+			tent.turkey: 1
+			spen.turkey: 1
+			syrd.turkey: 1
+			hpad.turkey: 4
+			afld.turkey: 4
+			weap.turkey: 1
+			atek.turkey: 1
+			stek.turkey: 1
+			fix.turkey: 1
 		BuildingFractions:
 			proc: 29%
 			powr: 1%
@@ -425,6 +802,46 @@ Player:
 			agun: 5%
 			sam: 5%
 			mslo: 1%
+			proc.russia: 29%
+			powr.russia: 1%
+			apwr.russia: 24%
+			dome.russia: 1%
+			weap.russia: 1%
+			hpad.russia: 20%
+			afld.russia: 20%
+			atek.russia: 1%
+			stek.russia: 1%
+			spen.russia: 1%
+			syrd.russia: 1%
+			fix.russia: 0.1%
+			pbox.russia: 12%
+			gun.russia: 12%
+			ftur.russia: 12%
+			tsla.russia: 12%
+			agun.russia: 5%
+			sam.russia: 5%
+			mslo.russia: 1%
+			powr.greece: 1%
+			apwr.greece: 24%
+			proc.turkey: 29%
+			powr.turkey: 1%
+			apwr.turkey: 24%
+			dome.turkey: 1%
+			weap.turkey: 1%
+			hpad.turkey: 20%
+			afld.turkey: 20%
+			atek.turkey: 1%
+			stek.turkey: 1%
+			spen.turkey: 1%
+			syrd.turkey: 1%
+			fix.turkey: 0.1%
+			pbox.turkey: 12%
+			gun.turkey: 12%
+			ftur.turkey: 12%
+			tsla.turkey: 12%
+			agun.turkey: 5%
+			sam.turkey: 5%
+			mslo.turkey: 1%
 		UnitsToBuild:
 			harv: 1%
 			heli: 30%
@@ -436,8 +853,30 @@ Player:
 			dd: 30%
 			ca: 20%
 			pt: 10%
+			harv.russia: 1%
+			heli.russia: 30%
+			hind.russia: 30%
+			mig.russia: 30%
+			yak.russia: 30%
+			ss.russia: 10%
+			msub.russia: 30%
+			dd.russia: 30%
+			ca.russia: 20%
+			pt.russia: 10%
+			harv.turkey: 1%
+			heli.turkey: 30%
+			hind.turkey: 30%
+			mig.turkey: 30%
+			yak.turkey: 30%
+			ss.turkey: 10%
+			msub.turkey: 30%
+			dd.turkey: 30%
+			ca.turkey: 20%
+			pt.turkey: 10%
 		UnitLimits:
 			harv: 8
+			harv.russia: 8
+			harv.turkey: 8
 		SquadSize: 1
 		SupportPowerDecision@spyplane:
 			OrderName: SovietSpyPlane

--- a/mods/raclassic/rules/aircraft.yaml
+++ b/mods/raclassic/rules/aircraft.yaml
@@ -76,11 +76,15 @@ BADR.Bomber:
 MIG:
 	Inherits: ^Plane
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 117
 	Buildable:
 		Queue: Aircraft
 		BuildAtProductionType: Plane
+		BuildDuration: 1200
 		BuildPaletteOrder: 50
-		Prerequisites: ~afld, ~techlevel.7
+		Prerequisites: ~afld, ~player.normal, ~techlevel.7
 		Description: Fast Ground-Attack Plane.\n  Strong vs Buildings, Tanks\n  Weak vs Infantry, Light armor, Aircraft
 	Valued:
 		Cost: 1200
@@ -114,6 +118,7 @@ MIG:
 		AmmoCondition: ammo
 	ReturnOnIdle:
 	Selectable:
+		Class: MIG
 		Bounds: 36,28,0,2
 		DecorationBounds: 40,29,0,1
 	SelectionDecorations:
@@ -122,15 +127,21 @@ MIG:
 	SmokeTrailWhenDamaged:
 		Offset: -853,0,171
 		Interval: 2
+	RenderSprites:
+		Image: MIG
 
 YAK:
 	Inherits: ^Plane
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 120
 	Buildable:
 		Queue: Aircraft
 		BuildAtProductionType: Plane
+		BuildDuration: 800
 		BuildPaletteOrder: 30
-		Prerequisites: ~afld, ~techlevel.3
+		Prerequisites: ~afld, ~player.normal, ~techlevel.3
 		Description: Anti-Tanks & Anti-Infantry Plane.\n  Strong vs Infantry, Vehicles\n  Weak vs Aircraft
 	Valued:
 		Cost: 800
@@ -178,15 +189,19 @@ YAK:
 		Offset: -853,0,0
 		Interval: 2
 	Selectable:
+		Class: YAK
 		DecorationBounds: 30,28,0,2
+	RenderSprites:
+		Image: YAK
 
 TRAN:
 	Inherits: ^Helicopter
 	Buildable:
 		Queue: Aircraft
 		BuildAtProductionType: Helicopter
+		BuildDuration: 1200
 		BuildPaletteOrder: 10
-		Prerequisites: ~hpad, ~techlevel.8
+		Prerequisites: ~hpad, ~player.normal, ~techlevel.8
 		Description: Fast Infantry Transport Helicopter.\n  Unarmed
 	Valued:
 		Cost: 1200
@@ -230,16 +245,23 @@ TRAN:
 		Actor: TRAN.Husk
 	SelectionDecorations:
 	Selectable:
+		Class: TRAN
 		DecorationBounds: 40,36
+	RenderSprites:
+		Image: TRAN
 
 HELI:
 	Inherits: ^Helicopter
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 125
 	Buildable:
 		Queue: Aircraft
 		BuildAtProductionType: Helicopter
+		BuildDuration: 1200
 		BuildPaletteOrder: 40
-		Prerequisites: ~hpad, ~heli.allies, ~techlevel.6
+		Prerequisites: ~hpad, ~heli.allies, ~player.normal, ~techlevel.6
 		Description: Helicopter gunship armed\nwith multi-purpose missiles.\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry
 	Valued:
 		Cost: 1200
@@ -282,16 +304,23 @@ HELI:
 	SmokeTrailWhenDamaged:
 		Offset: -427,0,0
 	Selectable:
+		Class: HELI
 		DecorationBounds: 36,28
+	RenderSprites:
+		Image: HELI
 
 HIND:
 	Inherits: ^Helicopter
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 120
 	Buildable:
 		Queue: Aircraft
 		BuildAtProductionType: Helicopter
+		BuildDuration: 1200
 		BuildPaletteOrder: 20
-		Prerequisites: ~hpad, ~heli.soviet, ~techlevel.6
+		Prerequisites: ~hpad, ~heli.soviet, ~player.normal, ~techlevel.6
 		Description: Helicopter gunship armed\nwith dual chainguns.\n  Strong vs Infantry, Light armor.\n  Weak vs Tanks, Aircraft
 	Valued:
 		Cost: 1200
@@ -341,7 +370,10 @@ HIND:
 	SmokeTrailWhenDamaged:
 		Offset: -427,0,0
 	Selectable:
+		Class: HIND
 		DecorationBounds: 38,32
+	RenderSprites:
+		Image: HIND
 
 U2:
 	Inherits: ^Plane

--- a/mods/raclassic/rules/country-duplicates.yaml
+++ b/mods/raclassic/rules/country-duplicates.yaml
@@ -1,0 +1,1038 @@
+# BUILDINGS
+POWR.russia:
+	Inherits: POWR
+	Buildable:
+		Prerequisites: ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 270
+
+POWR.greece:
+	Inherits: POWR
+	Buildable:
+		Prerequisites: ~player.greece, ~techlevel.1
+	Power:
+		Amount: 110
+
+POWR.turkey:
+	Inherits: POWR
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~player.turkey, ~techlevel.1
+
+APWR.russia:
+	Inherits: APWR
+	Buildable:
+		Prerequisites: anypower, ~player.russia, ~techlevel.5
+	Valued:
+		Cost: 449
+
+APWR.greece:
+	Inherits: APWR
+	Buildable:
+		Prerequisites: anypower, ~player.greece, ~techlevel.5
+	Power:
+		Amount: 220
+
+APWR.turkey:
+	Inherits: APWR
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: anypower, ~player.turkey, ~techlevel.5
+
+TENT.russia:
+	Inherits: TENT
+	Buildable:
+		Prerequisites: anypower, ~structures.allies, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 270
+
+TENT.turkey:
+	Inherits: TENT
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: anypower, ~structures.allies, ~player.turkey, ~techlevel.1
+
+BARR.russia:
+	Inherits: BARR
+	Buildable:
+		Prerequisites: anypower, ~structures.soviet, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 270
+
+BARR.turkey:
+	Inherits: BARR
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: anypower, ~structures.soviet, ~player.turkey, ~techlevel.1
+
+KENN.russia:
+	Inherits: KENN
+	Buildable:
+		Prerequisites: barr, ~structures.soviet, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 180
+
+KENN.turkey:
+	Inherits: KENN
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: barr, ~structures.soviet, ~player.turkey, ~techlevel.2
+
+PROC.russia:
+	Inherits: PROC
+	Buildable:
+		Prerequisites: anypower, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 1797
+	FreeActor:
+		Actor: HARV.russia
+
+PROC.turkey:
+	Inherits: PROC
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: anypower, ~player.turkey, ~techlevel.1
+	FreeActor:
+		Actor: HARV.turkey
+
+SILO.russia:
+	Inherits: SILO
+	Buildable:
+		Prerequisites: proc, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 135
+
+SILO.turkey:
+	Inherits: SILO
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: proc, ~player.turkey, ~techlevel.1
+
+SYRD.russia:
+	Inherits: SYRD
+	Buildable:
+		Prerequisites: anypower, ~structures.allies, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 584
+
+SYRD.turkey:
+	Inherits: SYRD
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: anypower, ~structures.allies, ~player.turkey, ~techlevel.2
+
+SPEN.russia:
+	Inherits: SPEN
+	Buildable:
+		Prerequisites: anypower, ~structures.soviet, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 584
+
+SPEN.turkey:
+	Inherits: SPEN
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: anypower, ~structures.soviet, ~player.turkey, ~techlevel.2
+
+WEAP.russia:
+	Inherits: WEAP
+	Buildable:
+		Prerequisites: proc, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 1797
+
+WEAP.turkey:
+	Inherits: WEAP
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: proc, ~player.turkey, ~techlevel.2
+
+FIX.russia:
+	Inherits: FIX
+	Buildable:
+		Prerequisites: weap, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 1078
+
+FIX.turkey:
+	Inherits: FIX
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: weap, ~player.turkey, ~techlevel.2
+
+DOME.russia:
+	Inherits: DOME
+	Buildable:
+		Prerequisites: proc, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 898
+
+DOME.turkey:
+	Inherits: DOME
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: proc, ~player.turkey, ~techlevel.2
+
+HPAD.russia:
+	Inherits: HPAD
+	Buildable:
+		Prerequisites: dome, ~player.russia, ~techlevel.6
+	Valued:
+		Cost: 1348
+
+HPAD.turkey:
+	Inherits: HPAD
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: dome, ~player.turkey, ~techlevel.6
+
+AFLD.russia:
+	Inherits: AFLD
+	Buildable:
+		Prerequisites: dome, ~structures.soviet, ~player.russia, ~techlevel.3
+	Valued:
+		Cost: 539
+
+AFLD.turkey:
+	Inherits: AFLD
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: dome, ~structures.soviet, ~player.turkey, ~techlevel.3
+
+ATEK.russia:
+	Inherits: ATEK
+	Buildable:
+		Prerequisites: weap, dome, ~structures.allies, ~player.russia, ~techlevel.7
+	Valued:
+		Cost: 1348
+
+ATEK.turkey:
+	Inherits: ATEK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: weap, dome, ~structures.allies, ~player.turkey, ~techlevel.7
+
+STEK.russia:
+	Inherits: STEK
+	Buildable:
+		Prerequisites: weap, dome, ~structures.soviet, ~player.russia, ~techlevel.4
+	Valued:
+		Cost: 1348
+
+STEK.turkey:
+	Inherits: STEK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: weap, dome, ~structures.soviet, ~player.turkey, ~techlevel.4
+
+PDOX.russia:
+	Inherits: PDOX
+	Buildable:
+		Prerequisites: atek, ~structures.allies, ~player.russia, ~techlevel.9
+	Valued:
+		Cost: 2516
+
+PDOX.turkey:
+	Inherits: PDOX
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: atek, ~structures.allies, ~player.turkey, ~techlevel.9
+
+IRON.russia:
+	Inherits: IRON
+	Buildable:
+		Prerequisites: stek, ~structures.soviet, ~player.russia, ~techlevel.9
+	Valued:
+		Cost: 2516
+
+IRON.turkey:
+	Inherits: IRON
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: stek, ~structures.soviet, ~player.turkey, ~techlevel.9
+
+MSLO.russia:
+	Inherits: MSLO
+	Buildable:
+		Prerequisites: techcenter, ~player.russia, ~techlevel.10
+	Valued:
+		Cost: 2246
+
+MSLO.turkey:
+	Inherits: MSLO
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: techcenter, ~player.turkey, ~techlevel.10
+
+# DEFENSES
+SBAG.russia:
+	Inherits: SBAG
+	Buildable:
+		Prerequisites: fact, ~structures.allies, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 22
+
+SBAG.turkey:
+	Inherits: SBAG
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: fact, ~structures.allies, ~player.turkey, ~techlevel.1
+
+FENC.russia:
+	Inherits: FENC
+	Buildable:
+		Prerequisites: fact, ~structures.soviet, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 22
+
+FENC.turkey:
+	Inherits: FENC
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: fact, ~structures.soviet, ~player.turkey, ~techlevel.1
+
+BRIK.russia:
+	Inherits: BRIK
+	Buildable:
+		Prerequisites: fact, ~player.russia, ~techlevel.5
+	Valued:
+		Cost: 45
+
+BRIK.turkey:
+	Inherits: BRIK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: fact, ~player.turkey, ~techlevel.5
+
+PBOX.russia:
+	Inherits: PBOX
+	Buildable:
+		Prerequisites: tent, ~structures.allies, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 359
+
+PBOX.turkey:
+	Inherits: PBOX
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: tent, ~structures.allies, ~player.turkey, ~techlevel.1
+
+HBOX.russia:
+	Inherits: HBOX
+	Buildable:
+		Prerequisites: tent, ~structures.allies, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 539
+
+HBOX.turkey:
+	Inherits: HBOX
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: tent, ~structures.allies, ~player.turkey, ~techlevel.2
+
+FTUR.russia:
+	Inherits: FTUR
+	Buildable:
+		Prerequisites: barr, ~structures.soviet, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 539
+
+FTUR.turkey:
+	Inherits: FTUR
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: barr, ~structures.soviet, ~player.turkey, ~techlevel.1
+
+GUN.russia:
+	Inherits: GUN
+	Buildable:
+		Prerequisites: tent, ~structures.allies, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 719
+
+GUN.turkey:
+	Inherits: GUN
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: tent, ~structures.allies, ~player.turkey, ~techlevel.2
+
+TSLA.russia:
+	Inherits: TSLA
+	Buildable:
+		Prerequisites: weap, ~structures.soviet, ~player.russia, ~techlevel.5
+	Valued:
+		Cost: 1348
+
+TSLA.turkey:
+	Inherits: TSLA
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: weap, ~structures.soviet, ~player.turkey, ~techlevel.5
+
+AGUN.russia:
+	Inherits: AGUN
+	Buildable:
+		Prerequisites: dome, ~structures.allies, ~player.russia, ~techlevel.3
+	Valued:
+		Cost: 539
+
+AGUN.turkey:
+	Inherits: AGUN
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: dome, ~structures.allies, ~player.turkey, ~techlevel.3
+
+SAM.russia:
+	Inherits: SAM
+	Buildable:
+		Prerequisites: dome, ~structures.soviet, ~player.russia, ~techlevel.6
+	Valued:
+		Cost: 674
+
+SAM.turkey:
+	Inherits: SAM
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: dome, ~structures.soviet, ~player.turkey, ~techlevel.6
+
+GAP.russia:
+	Inherits: GAP
+	Buildable:
+		Prerequisites: atek, ~structures.allies, ~player.russia, ~techlevel.7
+	Valued:
+		Cost: 449
+
+GAP.turkey:
+	Inherits: GAP
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: atek, ~structures.allies, ~player.turkey, ~techlevel.7
+
+# FAKES
+SYRF.russia:
+	Inherits: SYRF
+	Buildable:
+		Prerequisites: anypower, ~structures.allies, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 45
+
+SYRF.turkey:
+	Inherits: SYRF
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: anypower, ~structures.allies, ~player.turkey, ~techlevel.2
+
+SPEF.russia:
+	Inherits: SPEF
+	Buildable:
+		Prerequisites: anypower, ~disabled, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 45
+
+SPEF.turkey:
+	Inherits: SPEF
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: anypower, ~disabled, ~player.turkey, ~techlevel.2
+
+WEAF.russia:
+	Inherits: WEAF
+	Buildable:
+		Prerequisites: proc, ~structures.allies, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 45
+
+WEAF.turkey:
+	Inherits: WEAF
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: proc, ~structures.allies, ~player.turkey, ~techlevel.2
+
+DOMF.russia:
+	Inherits: DOMF
+	Buildable:
+		Prerequisites: proc, ~structures.allies, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 45
+
+DOMF.turkey:
+	Inherits: DOMF
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: proc, ~structures.allies, ~player.turkey, ~techlevel.2
+
+FACF.russia:
+	Inherits: FACF
+	Buildable:
+		Prerequisites: ~structures.allies, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 45
+
+FACF.turkey:
+	Inherits: FACF
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~structures.allies, ~player.turkey, ~techlevel.1
+
+# INFANTRY
+DOG.russia:
+	Inherits: DOG
+	Buildable:
+		Prerequisites: ~kenn, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 180
+
+DOG.turkey:
+	Inherits: DOG
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~kenn, ~player.turkey, ~techlevel.2
+
+E1.russia:
+	Inherits: E1
+	Buildable:
+		Prerequisites: ~barracks, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 90
+
+E1.turkey:
+	Inherits: E1
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~barracks, ~player.turkey, ~techlevel.1
+
+E2.russia:
+	Inherits: E2
+	Buildable:
+		Prerequisites: ~barr, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 144
+
+E2.turkey:
+	Inherits: E2
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~barr, ~player.turkey, ~techlevel.1
+
+E3.russia:
+	Inherits: E3
+	Buildable:
+		Prerequisites: ~barracks, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 270
+
+E3.turkey:
+	Inherits: E3
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~barracks, ~player.turkey, ~techlevel.1
+
+E4.russia:
+	Inherits: E4
+	Buildable:
+		Prerequisites: ~barr, stek, ~player.russia, ~techlevel.4
+	Valued:
+		Cost: 270
+
+E4.turkey:
+	Inherits: E4
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~barr, stek, ~player.turkey, ~techlevel.4
+
+E4.russia:
+	Inherits: E4
+	Buildable:
+		Prerequisites: ~barr, stek, ~player.russia, ~techlevel.4
+	Valued:
+		Cost: 270
+
+E4.turkey:
+	Inherits: E4
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~barr, stek, ~player.turkey, ~techlevel.4
+
+E6.russia:
+	Inherits: E6
+	Buildable:
+		Prerequisites: ~barracks, ~player.russia, ~techlevel.3
+	Valued:
+		Cost: 449
+
+E6.turkey:
+	Inherits: E6
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~barracks, ~player.turkey, ~techlevel.3
+
+SPY.russia:
+	Inherits: SPY
+	Buildable:
+		Prerequisites: dome, ~tent, ~player.russia, ~techlevel.4
+	Valued:
+		Cost: 449
+
+SPY.turkey:
+	Inherits: SPY
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: dome, ~tent, ~player.turkey, ~techlevel.4
+
+E7.russia:
+	Inherits: E7
+	Buildable:
+		Prerequisites: ~barracks, techcenter, ~player.russia, ~techlevel.8
+	Valued:
+		Cost: 1078
+
+E7.turkey:
+	Inherits: E7
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~barracks, techcenter, ~player.turkey, ~techlevel.8
+
+MEDI.russia:
+	Inherits: MEDI
+	Buildable:
+		Prerequisites: ~tent, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 719
+
+MEDI.turkey:
+	Inherits: MEDI
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~tent, ~player.turkey, ~techlevel.1
+
+MECH.russia:
+	Inherits: MECH
+	Buildable:
+		Prerequisites: ~tent, fix, ~global-aftermath, ~player.russia, ~techlevel.5
+	Valued:
+		Cost: 854
+
+MECH.turkey:
+	Inherits: MECH
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~tent, fix, ~global-aftermath, ~player.turkey, ~techlevel.5
+
+THF.russia:
+	Inherits: THF
+	Buildable:
+		Prerequisites: ~tent, atek, ~player.russia, ~techlevel.8
+	Valued:
+		Cost: 499
+
+THF.turkey:
+	Inherits: THF
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~tent, atek, ~player.turkey, ~techlevel.8
+
+SHOK.russia:
+	Inherits: SHOK
+	Buildable:
+		Prerequisites: ~barr, tsla, ~global-aftermath, ~player.russia, ~techlevel.5
+	Valued:
+		Cost: 809
+
+SHOK.turkey:
+	Inherits: SHOK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~barr, tsla, ~global-aftermath, ~player.turkey, ~techlevel.5
+
+# VEHICLES
+V2RL.russia:
+	Inherits: V2RL
+	Buildable:
+		Prerequisites: dome, ~vehicles.soviet, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 629
+
+V2RL.turkey:
+	Inherits: V2RL
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: dome, ~vehicles.soviet, ~player.turkey, ~techlevel.2
+
+1TNK.russia:
+	Inherits: 1TNK
+	Buildable:
+		Prerequisites: ~vehicles.allies, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 629
+
+1TNK.turkey:
+	Inherits: 1TNK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.allies, ~player.turkey, ~techlevel.2
+
+2TNK.russia:
+	Inherits: 2TNK
+	Buildable:
+		Prerequisites: ~vehicles.allies, ~player.russia, ~techlevel.4
+	Valued:
+		Cost: 719
+
+2TNK.turkey:
+	Inherits: 2TNK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.allies, ~player.turkey, ~techlevel.4
+
+3TNK.russia:
+	Inherits: 3TNK
+	Buildable:
+		Prerequisites: ~vehicles.soviet, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 854
+
+3TNK.turkey:
+	Inherits: 3TNK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.soviet, ~player.turkey, ~techlevel.2
+
+4TNK.russia:
+	Inherits: 4TNK
+	Buildable:
+		Prerequisites: stek, ~vehicles.soviet, ~player.russia, ~techlevel.7
+	Valued:
+		Cost: 854
+
+4TNK.turkey:
+	Inherits: 4TNK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: stek, ~vehicles.soviet, ~player.turkey, ~techlevel.7
+
+ARTY.russia:
+	Inherits: ARTY
+	Buildable:
+		Prerequisites: ~vehicles.allies, ~player.russia, ~techlevel.5
+	Valued:
+		Cost: 539
+
+ARTY.turkey:
+	Inherits: ARTY
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.allies, ~player.turkey, ~techlevel.5
+
+HARV.russia:
+	Inherits: HARV
+	Buildable:
+		Prerequisites: proc, ~player.russia, ~techlevel.1
+	Valued:
+		Cost: 1258
+
+HARV.turkey:
+	Inherits: HARV
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: proc, ~player.turkey, ~techlevel.1
+
+MCV.russia:
+	Inherits: MCV
+	Buildable:
+		Prerequisites: fix, ~player.russia, ~techlevel.8
+	Valued:
+		Cost: 2246
+
+MCV.turkey:
+	Inherits: MCV
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: fix, ~player.turkey, ~techlevel.8
+
+JEEP.russia:
+	Inherits: JEEP
+	Buildable:
+		Prerequisites: ~vehicles.allies, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 539
+
+JEEP.turkey:
+	Inherits: JEEP
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.allies, ~player.turkey, ~techlevel.2
+
+APC.russia:
+	Inherits: APC
+	Buildable:
+		Prerequisites: ~vehicles.allies, tent, ~player.russia, ~techlevel.3
+	Valued:
+		Cost: 719
+
+APC.turkey:
+	Inherits: APC
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.allies, tent, ~player.turkey, ~techlevel.3
+
+MNLY.AP.russia:
+	Inherits: MNLY.AP
+	Buildable:
+		Prerequisites: ~vehicles.soviet, fix, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 719
+
+MNLY.AP.turkey:
+	Inherits: MNLY.AP
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.soviet, fix, ~player.turkey, ~techlevel.2
+
+MNLY.AV.russia:
+	Inherits: MNLY.AV
+	Buildable:
+		Prerequisites: ~vehicles.allies, fix, ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 719
+
+MNLY.AV.turkey:
+	Inherits: MNLY.AV
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.allies, fix, ~player.turkey, ~techlevel.2
+
+MGG.russia:
+	Inherits: MGG
+	Buildable:
+		Prerequisites: ~vehicles.allies, atek, ~player.russia, ~techlevel.8
+	Valued:
+		Cost: 539
+
+MGG.turkey:
+	Inherits: MGG
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.allies, atek, ~player.turkey, ~techlevel.8
+
+MRJ.russia:
+	Inherits: MRJ
+	Buildable:
+		Prerequisites: ~vehicles.allies, dome, ~player.russia, ~techlevel.9
+	Valued:
+		Cost: 539
+
+MRJ.turkey:
+	Inherits: MRJ
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.allies, dome, ~player.turkey, ~techlevel.9
+
+TTNK.russia:
+	Inherits: TTNK
+	Buildable:
+		Prerequisites: ~vehicles.soviet, tsla, ~global-aftermath, ~player.russia, ~techlevel.5
+	Valued:
+		Cost: 1348
+
+TTNK.turkey:
+	Inherits: TTNK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.soviet, tsla, ~global-aftermath, ~player.turkey, ~techlevel.5
+
+DTRK.russia:
+	Inherits: DTRK
+	Buildable:
+		Prerequisites: mslo, ~global-aftermath, ~player.russia, ~techlevel.10
+	Valued:
+		Cost: 2156
+
+DTRK.turkey:
+	Inherits: DTRK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: mslo, ~global-aftermath, ~player.turkey, ~techlevel.10
+
+CTNK.russia:
+	Inherits: CTNK
+	Buildable:
+		Prerequisites: ~vehicles.allies, atek, ~global-aftermath, ~player.russia, ~techlevel.9
+	Valued:
+		Cost: 2156
+
+CTNK.turkey:
+	Inherits: CTNK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.allies, atek, ~global-aftermath, ~player.turkey, ~techlevel.9
+
+QTNK.russia:
+	Inherits: QTNK
+	Buildable:
+		Prerequisites: ~vehicles.soviet, stek, ~global-aftermath, ~player.russia, ~techlevel.7
+	Valued:
+		Cost: 2066
+
+QTNK.turkey:
+	Inherits: QTNK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.soviet, stek, ~global-aftermath, ~player.turkey, ~techlevel.7
+
+STNK.russia:
+	Inherits: STNK
+	Buildable:
+		Prerequisites: ~vehicles.allies, atek, ~player.russia, ~disabled
+	Valued:
+		Cost: 719
+
+STNK.turkey:
+	Inherits: STNK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~vehicles.allies, atek, ~player.turkey, ~disabled
+
+# SHIPS
+SS.russia:
+	Inherits: SS
+	Buildable:
+		Prerequisites: ~spen, ~player.russia, ~techlevel.3
+	Valued:
+		Cost: 854
+
+SS.turkey:
+	Inherits: SS
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~spen, ~player.turkey, ~techlevel.3
+
+MSUB.russia:
+	Inherits: MSUB
+	Buildable:
+		Prerequisites: ~spen, stek, ~global-aftermath, ~player.russia, ~techlevel.6
+	Valued:
+		Cost: 1428
+
+MSUB.turkey:
+	Inherits: MSUB
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~spen, stek, ~global-aftermath, ~player.turkey, ~techlevel.6
+
+DD.russia:
+	Inherits: DD
+	Buildable:
+		Prerequisites: ~syrd, dome, ~player.russia, ~techlevel.5
+	Valued:
+		Cost: 898
+
+DD.turkey:
+	Inherits: DD
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~syrd, dome, ~player.turkey, ~techlevel.5
+
+CA.russia:
+	Inherits: CA
+	Buildable:
+		Prerequisites: ~syrd, atek, ~player.russia, ~techlevel.7
+	Valued:
+		Cost: 1797
+
+CA.turkey:
+	Inherits: CA
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~syrd, atek, ~player.turkey, ~techlevel.7
+
+LST.russia:
+	Inherits: LST
+	Buildable:
+		Prerequisites: ~player.russia, ~techlevel.2
+	Valued:
+		Cost: 629
+
+LST.turkey:
+	Inherits: LST
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~player.turkey, ~techlevel.2
+
+PT.russia:
+	Inherits: PT
+	Buildable:
+		Prerequisites: ~syrd, ~player.russia, ~techlevel.3
+	Valued:
+		Cost: 449
+
+PT.turkey:
+	Inherits: PT
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~syrd, ~player.turkey, ~techlevel.3
+
+# AIRCRAFT
+MIG.russia:
+	Inherits: MIG
+	Buildable:
+		Prerequisites: ~afld, ~player.russia, ~techlevel.7
+	Valued:
+		Cost: 1078
+
+MIG.turkey:
+	Inherits: MIG
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~afld, ~player.turkey, ~techlevel.7
+
+YAK.russia:
+	Inherits: YAK
+	Buildable:
+		Prerequisites: ~afld, ~player.russia, ~techlevel.3
+	Valued:
+		Cost: 719
+
+YAK.turkey:
+	Inherits: YAK
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~afld, ~player.turkey, ~techlevel.3
+
+TRAN.russia:
+	Inherits: TRAN
+	Buildable:
+		Prerequisites: ~hpad, ~player.russia, ~techlevel.8
+	Valued:
+		Cost: 1078
+
+TRAN.turkey:
+	Inherits: TRAN
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~hpad, ~player.turkey, ~techlevel.8
+
+HELI.russia:
+	Inherits: HELI
+	Buildable:
+		Prerequisites: ~hpad, ~heli.allies, ~player.russia, ~techlevel.6
+	Valued:
+		Cost: 1078
+
+HELI.turkey:
+	Inherits: HELI
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~hpad, ~heli.allies, ~player.turkey, ~techlevel.6
+
+HIND.russia:
+	Inherits: HIND
+	Buildable:
+		Prerequisites: ~hpad, ~heli.soviet, ~player.russia, ~techlevel.6
+	Valued:
+		Cost: 1078
+
+HIND.turkey:
+	Inherits: HIND
+	Buildable:
+		BuildDurationModifier: 54
+		Prerequisites: ~hpad, ~heli.soviet, ~player.turkey, ~techlevel.6

--- a/mods/raclassic/rules/defaults.yaml
+++ b/mods/raclassic/rules/defaults.yaml
@@ -40,6 +40,38 @@
 			TopLeft: -1536, -1024
 			BottomRight: 1536, 1024
 
+^AffectedByCountryBonuses:
+	DamageMultiplier@England:
+		RequiresCondition: england
+		Modifier: 90
+	FirepowerMultiplier@Germany:
+		RequiresCondition: germany
+		Modifier: 110
+	ReloadDelayMultiplier@France:
+		RequiresCondition: france
+		Modifier: 90
+	SpeedMultiplier@Ukraine:
+		RequiresCondition: ukraine
+		Modifier: 110
+	GrantConditionOnPrerequisite@England:
+		Condition: england
+		Prerequisites: player.england
+	GrantConditionOnPrerequisite@Germany:
+		Condition: germany
+		Prerequisites: player.england
+	GrantConditionOnPrerequisite@France:
+		Condition: france
+		Prerequisites: player.france
+	GrantConditionOnPrerequisite@Spain:
+		Condition: spain
+		Prerequisites: player.spain
+	GrantConditionOnPrerequisite@Greece:
+		Condition: greece
+		Prerequisites: player.greece
+	GrantConditionOnPrerequisite@Ukraine:
+		Condition: ukraine
+		Prerequisites: player.ukraine
+
 ^IronCurtainable:
 	WithColoredOverlay@IRONCURTAIN:
 		RequiresCondition: invulnerability
@@ -103,6 +135,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^IronCurtainable
 	Inherits@3: ^SpriteActor
+	Inherits@4: ^AffectedByCountryBonuses
 	Huntable:
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
@@ -125,6 +158,7 @@
 		TargetTypes: Ground, Repair, Vehicle
 		RequiresCondition: !parachute
 	Repairable:
+		RepairBuildings: fix, fix.russia, fix.turkey
 	Chronoshiftable:
 	Sellable:
 		SellSounds: cashturn.aud
@@ -208,6 +242,7 @@
 ^Infantry:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
+	Inherits@3: ^AffectedByCountryBonuses
 	Huntable:
 	DrawLineToTarget:
 	Health:
@@ -330,6 +365,9 @@
 
 ^ArmedCivilian:
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 157
 	Armament:
 		Weapon: Pistol
 	AttackFrontal:
@@ -340,6 +378,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^IronCurtainable
 	Inherits@3: ^SpriteActor
+	Inherits@4: ^AffectedByCountryBonuses
 	Huntable:
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
@@ -361,6 +400,7 @@
 		Types: Ship
 	Chronoshiftable:
 	RepairableNear:
+		Buildings: syrd, syrd.russia, syrd.turkey, spen, spen.russia, spen.turkey
 	WithDamageOverlay:
 	Explodes:
 		Weapon: UnitExplodeShip
@@ -380,8 +420,9 @@
 
 ^Plane:
 	Inherits@1: ^ExistsInWorld
-	Inherits@3: ^IronCurtainable
-	Inherits@4: ^SpriteActor
+	Inherits@2: ^IronCurtainable
+	Inherits@3: ^SpriteActor
+	Inherits@4: ^AffectedByCountryBonuses
 	Huntable:
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
@@ -392,8 +433,8 @@
 	Selectable:
 		Bounds: 24,24
 	Aircraft:
-		RepairBuildings: fix
-		RearmBuildings: afld
+		RepairBuildings: fix, fix.russia, fix.turkey
+		RearmBuildings: afld, afld.russia, afld.turkey
 		AirborneCondition: airborne
 	Targetable@GROUND:
 		TargetTypes: Ground, Repair, Vehicle
@@ -449,7 +490,7 @@
 	Tooltip:
 		GenericName: Helicopter
 	Aircraft:
-		RearmBuildings: hpad
+		RearmBuildings: hpad, hpad.russia, hpad.turkey
 		CanHover: True
 		CruisingCondition: cruising
 		WaitDistanceFromResupplyBase: 4c0
@@ -502,6 +543,7 @@
 
 ^Building:
 	Inherits: ^BasicBuilding
+	Inherits@1: ^AffectedByCountryBonuses
 	Huntable:
 	UpdatesPlayerStatistics:
 	GivesBuildableArea:
@@ -535,6 +577,7 @@
 ^Wall:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
+	Inherits@3: ^AffectedByCountryBonuses
 	Inherits@shape: ^1x1Shape
 	Interactable:
 	Building:

--- a/mods/raclassic/rules/fakes.yaml
+++ b/mods/raclassic/rules/fakes.yaml
@@ -2,9 +2,10 @@ SYRF:
 	Inherits: ^FakeBuilding
 	Inherits@infiltrate: ^InfiltratableFake
 	Buildable:
-		BuildPaletteOrder: 870
 		Queue: Building
-		Prerequisites: anypower, ~structures.allies, ~techlevel.2
+		BuildDuration: 50
+		BuildPaletteOrder: 860
+		Prerequisites: anypower, ~structures.allies, ~player.normal, ~techlevel.2
 		Description: Looks like a Naval Yard.
 		Icon: fake-icon
 	Tooltip:
@@ -18,6 +19,8 @@ SYRF:
 		Footprint: XXX xxx XXX
 		Dimensions: 3,3
 		TerrainTypes: Water
+	Selectable:
+		Class: SYRF
 	RenderSprites:
 		Image: SYRD
 	EditorTilesetFilter:
@@ -41,9 +44,10 @@ SPEF:
 	Targetable:
 		TargetTypes: Ground, Water, Structure, SpyInfiltrate
 	Buildable:
-		BuildPaletteOrder: 870
 		Queue: Building
-		Prerequisites: anypower, ~disabled, ~techlevel.2
+		BuildDuration: 50
+		BuildPaletteOrder: 870
+		Prerequisites: anypower, ~disabled, ~player.normal, ~techlevel.2
 		Description: Looks like a Sub Pen.
 		Icon: fake-icon
 	Tooltip:
@@ -55,6 +59,8 @@ SPEF:
 		Footprint: XXX xxx XXX
 		Dimensions: 3,3
 		TerrainTypes: Water
+	Selectable:
+		Class: SPEF
 	RenderSprites:
 		Image: SPEN
 	EditorTilesetFilter:
@@ -76,9 +82,10 @@ WEAF:
 	Inherits@infiltrate: ^InfiltratableFake
 	Inherits@shape: ^3x2Shape
 	Buildable:
-		BuildPaletteOrder: 880
-		Prerequisites: proc, ~structures.allies, ~techlevel.2
 		Queue: Building
+		BuildDuration: 50
+		BuildPaletteOrder: 880
+		Prerequisites: proc, ~structures.allies, ~player.normal, ~techlevel.2
 		Description: Looks like a War Factory.
 		Icon: fake-icon
 	Tooltip:
@@ -91,6 +98,8 @@ WEAF:
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
 	WithBuildingBib:
+	Selectable:
+		Class: WEAF
 	RenderSprites:
 		Image: WEAP
 	WithProductionDoorOverlay:
@@ -109,9 +118,10 @@ DOMF:
 		GenericVisibility: Enemy
 		GenericStancePrefix: False
 	Buildable:
-		BuildPaletteOrder: 890
 		Queue: Building
-		Prerequisites: proc, ~structures.allies, ~techlevel.2
+		BuildDuration: 50
+		BuildPaletteOrder: 890
+		Prerequisites: proc, ~structures.allies, ~player.normal, ~techlevel.2
 		Description: Looks like a Radar Dome.
 		Icon: fake-icon
 	Building:
@@ -119,15 +129,18 @@ DOMF:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	WithBuildingBib:
+	Selectable:
+		Class: DOMF
 	RenderSprites:
 		Image: DOME
 
 FACF:
 	Inherits: ^FakeBuilding
 	Buildable:
-		BuildPaletteOrder: 900
 		Queue: Building
-		Prerequisites: ~structures.allies, ~techlevel.1
+		BuildDuration: 50
+		BuildPaletteOrder: 900
+		Prerequisites: ~structures.allies, ~player.normal, ~techlevel.1
 		Description: Looks like a Construction Yard.
 		Icon: fake-icon
 	Tooltip:
@@ -140,6 +153,8 @@ FACF:
 		Dimensions: 3,4
 		LocalCenterOffset: 0,-512,0
 	WithBuildingBib:
+	Selectable:
+		Class: FACF
 	RenderSprites:
 		Image: FACT
 	HitShape:

--- a/mods/raclassic/rules/infantry.yaml
+++ b/mods/raclassic/rules/infantry.yaml
@@ -1,10 +1,14 @@
 DOG:
 	Inherits: ^Soldier
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 133
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Dog
-		BuildPaletteOrder: 50
-		Prerequisites: ~kenn, ~techlevel.2
+		BuildDuration: 200
+		BuildPaletteOrder: 60
+		Prerequisites: ~kenn, ~player.normal, ~techlevel.2
 		Description: Anti-infantry unit.\nCan detect spies.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
 	Valued:
 		Cost: 200
@@ -12,6 +16,7 @@ DOG:
 		Name: Attack Dog
 		GenericName: Dog
 	Selectable:
+		Class: DOG
 		Bounds: 12,17,-1,-4
 		DecorationBounds: 12,17,-1,-4
 	SelectionDecorations:
@@ -43,15 +48,21 @@ DOG:
 	Voiced:
 		VoiceSet: DogVoice
 	-TakeCover:
+	RenderSprites:
+		Image: DOG
 
 E1:
 	Inherits: ^Soldier
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 133
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
+		BuildDuration: 100
 		BuildPaletteOrder: 10
-		Prerequisites: ~barracks, ~techlevel.1
+		Prerequisites: ~barracks, ~player.normal, ~techlevel.1
 		Description: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
 	Selectable:
 		Class: E1
@@ -66,16 +77,24 @@ E1:
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
+	RenderSprites:
+		Image: E1
 
 E2:
 	Inherits: ^Soldier
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 125
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
+		BuildDuration: 160
 		BuildPaletteOrder: 40
-		Prerequisites: ~barr, ~techlevel.1
+		Prerequisites: ~barr, ~player.normal, ~techlevel.1
 		Description: Infantry armed with grenades.\n  Strong vs Buildings, Infantry\n  Weak vs Vehicles, Aircraft
+	Selectable:
+		Class: E2
 	Valued:
 		Cost: 160
 	Tooltip:
@@ -96,6 +115,8 @@ E2:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		Chance: 50
+	RenderSprites:
+		Image: E2
 
 E3:
 	Inherits: ^Soldier
@@ -103,8 +124,9 @@ E3:
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
+		BuildDuration: 300
 		BuildPaletteOrder: 20
-		Prerequisites: ~barracks, ~techlevel.1
+		Prerequisites: ~barracks, ~player.normal, ~techlevel.1
 		Description: Anti-tank/Anti-aircraft infantry.\n  Strong vs Vehicles, Aircraft\n  Weak vs Infantry
 	Selectable:
 		Class: E3
@@ -117,25 +139,44 @@ E3:
 	Armament@PRIMARY:
 		Weapon: RedEye
 		LocalOffset: 0,0,555
+		RequiresCondition: !spain
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: Dragon
 		LocalOffset: 0,0,555
+		RequiresCondition: !spain
+	Armament@PRIMARY_SPAIN:
+		Weapon: RedEye
+		LocalOffset: 0,0,555
+		RequiresCondition: spain
+	Armament@SECONDARY_SPAIN:
+		Name: secondary
+		Weapon: Dragon
+		LocalOffset: 0,0,555
+		RequiresCondition: spain
 	TakeCover:
 		ProneOffset: 384,0,-395
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
+	RenderSprites:
+		Image: E3
 
 E4:
 	Inherits: ^Soldier
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 129
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
-		BuildPaletteOrder: 100
-		Prerequisites: ~barr, stek, ~techlevel.4
+		BuildDuration: 300
+		BuildPaletteOrder: 110
+		Prerequisites: ~barr, stek, ~player.normal, ~techlevel.4
 		Description: Advanced anti-structure unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft
+	Selectable:
+		Class: E4
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -151,15 +192,20 @@ E4:
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
+	RenderSprites:
+		Image: E4
 
 E6:
 	Inherits: ^Soldier
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
-		BuildPaletteOrder: 40
-		Prerequisites: ~barracks, ~techlevel.3
+		BuildDuration: 500
+		BuildPaletteOrder: 50
+		Prerequisites: ~barracks, ~player.normal, ~techlevel.3
 		Description: Infiltrates and captures\nenemy structures.\n  Unarmed
+	Selectable:
+		Class: E6
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -176,15 +222,20 @@ E6:
 		VoiceSet: EngineerVoice
 	Selectable:
 		Priority: 5
+	RenderSprites:
+		Image: E6
 
 SPY:
 	Inherits: ^Soldier
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
-		BuildPaletteOrder: 70
-		Prerequisites: dome, ~tent, ~techlevel.4
+		BuildDuration: 500
+		BuildPaletteOrder: 80
+		Prerequisites: dome, ~tent, ~player.normal, ~techlevel.4
 		Description: Infiltrates enemy structures for intel.\nExact effect depends on the building infiltrated.
+	Selectable:
+		Class: SPY
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -202,16 +253,24 @@ SPY:
 		TargetTypes: Ground, Infantry, Spy
 	Voiced:
 		VoiceSet: SpyVoice
+	RenderSprites:
+		Image: SPY
 
 E7:
 	Inherits: ^Soldier
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 117
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
-		BuildPaletteOrder: 110
-		Prerequisites: ~barracks, techcenter, ~techlevel.8
+		BuildDuration: 1200
+		BuildPaletteOrder: 120
+		Prerequisites: ~barracks, techcenter, ~player.normal, ~techlevel.8
 		Description: Elite commando infantry. Armed with\ndual pistols and C4.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft\n  Special Ability: Destroy Building with C4
+	Selectable:
+		Class: E7
 	AutoTarget:
 		InitialStance: ReturnFire
 		InitialStanceAI: ReturnFire
@@ -246,15 +305,23 @@ E7:
 	AnnounceOnKill:
 	Voiced:
 		VoiceSet: TanyaVoice
+	RenderSprites:
+		Image: E7
 
 MEDI:
 	Inherits: ^Soldier
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 155
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
+		BuildDuration: 800
 		BuildPaletteOrder: 30
-		Prerequisites: ~tent, ~techlevel.1
+		Prerequisites: ~tent, ~player.normal, ~techlevel.1
 		Description: Heals nearby infantry.\n  Unarmed
+	Selectable:
+		Class: MEDI
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -280,15 +347,23 @@ MEDI:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: Infantry
+	RenderSprites:
+		Image: MEDI
 
 MECH:
 	Inherits: ^Soldier
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 155
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
-		BuildPaletteOrder: 80
-		Prerequisites: ~tent, fix, ~global-aftermath, ~techlevel.5
+		BuildDuration: 950
+		BuildPaletteOrder: 100
+		Prerequisites: ~tent, fix, ~global-aftermath, ~player.normal, ~techlevel.5
 		Description: Repairs nearby vehicles.\n  Unarmed
+	Selectable:
+		Class: MECH
 	Valued:
 		Cost: 950
 	Tooltip:
@@ -318,6 +393,8 @@ MECH:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: Vehicle
+	RenderSprites:
+		Image: MECH
 
 EINSTEIN:
 	Inherits: ^CivInfantry
@@ -379,9 +456,12 @@ THF:
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
+		BuildDuration: 500
 		BuildPaletteOrder: 90
-		Prerequisites: ~tent, atek, ~techlevel.8
+		Prerequisites: ~tent, atek, ~player.normal, ~techlevel.8
 		Description: Steals enemy credits.\n  Unarmed
+	Selectable:
+		Class: THF
 	RevealsShroud:
 		Range: 5c0
 	Passenger:
@@ -394,16 +474,24 @@ THF:
 	WithInfantryBody:
 		-IdleSequences:
 		StandSequences: stand
+	RenderSprites:
+		Image: THF
 
 SHOK:
 	Inherits: ^Soldier
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 117
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
-		BuildPaletteOrder: 60
-		Prerequisites: ~barr, tsla, ~global-aftermath, ~techlevel.5
+		BuildDuration: 900
+		BuildPaletteOrder: 70
+		Prerequisites: ~barr, tsla, ~global-aftermath, ~player.normal, ~techlevel.5
 		Description: Elite infantry with portable tesla coils.\n  Strong vs Infantry, Vehicles\n  Weak vs Aircraft
+	Selectable:
+		Class: SHOK
 	Valued:
 		Cost: 900
 	Tooltip:
@@ -413,8 +501,6 @@ SHOK:
 	Mobile:
 		Voice: Move
 	-Crushable:
-	RevealsShroud:
-		Range: 4c0
 	Armament@PRIMARY:
 		Weapon: PortaTesla
 		LocalOffset: 427,0,341
@@ -432,6 +518,8 @@ SHOK:
 		DefaultAttackSequence: shoot
 	Voiced:
 		VoiceSet: ShokVoice
+	RenderSprites:
+		Image: SHOK
 
 ANT:
 	Inherits: ^Infantry

--- a/mods/raclassic/rules/misc.yaml
+++ b/mods/raclassic/rules/misc.yaml
@@ -53,67 +53,67 @@ CRATE:
 	GiveUnitCrateAction@harv_all:
 		SelectionShares: 2
 		Units: harv
-		ValidFactions: allies
+		ValidFactions: allies, england, germany, france, spain, greece, turkey
 	GiveUnitCrateAction@harv_sov:
 		SelectionShares: 3
 		Units: harv
-		ValidFactions: soviet
+		ValidFactions: soviet, russia, ukraine
 	GiveUnitCrateAction@jeep:
 		SelectionShares: 2
 		Units: jeep
-		ValidFactions: allies
+		ValidFactions: allies, england, germany, france, spain, greece, turkey
 	GiveUnitCrateAction@apc:
 		SelectionShares: 2
 		Units: apc
-		ValidFactions: allies
+		ValidFactions: allies, england, germany, france, spain, greece, turkey
 	GiveUnitCrateAction@arty:
 		SelectionShares: 2
 		Units: arty
-		ValidFactions: allies
+		ValidFactions: allies, england, germany, france, spain, greece, turkey
 	GiveUnitCrateAction@v2rl:
 		SelectionShares: 3
 		Units: v2rl
-		ValidFactions: soviet
+		ValidFactions: soviet, russia, ukraine
 	GiveUnitCrateAction@1tnk:
 		SelectionShares: 2
 		Units: 1tnk
-		ValidFactions: allies
+		ValidFactions: allies, england, germany, france, spain, greece, turkey
 	GiveUnitCrateAction@2tnk:
 		SelectionShares: 2
 		Units: 2tnk
-		ValidFactions: allies
+		ValidFactions: allies, england, germany, france, spain, greece, turkey
 	GiveUnitCrateAction@3tnk:
 		SelectionShares: 4
 		Units: 3tnk
-		ValidFactions: soviet
+		ValidFactions: soviet, russia, ukraine
 	GiveUnitCrateAction@mrj:
 		SelectionShares: 2
 		Units: mrj
-		ValidFactions: allies
+		ValidFactions: allies, england, germany, france, spain, greece, turkey
 	GiveUnitCrateAction@mnly_all:
 		SelectionShares: 2
 		Units: mnly.av
-		ValidFactions: allies
+		ValidFactions: allies, england, germany, france, spain, greece, turkey
 	GiveUnitCrateAction@mnly_sov:
 		SelectionShares: 4
 		Units: mnly.ap
-		ValidFactions: soviet
+		ValidFactions: soviet, russia, ukraine
 	GiveUnitCrateAction@mcv_all:
 		SelectionShares: 2
 		Units: mcv
-		ValidFactions: allies
+		ValidFactions: allies, england, germany, france, spain, greece, turkey
 	GiveUnitCrateAction@mcv_sov:
 		SelectionShares: 3
 		Units: mcv
-		ValidFactions: soviet
+		ValidFactions: soviet, russia, ukraine
 	GiveUnitCrateAction@4tnk:
 		SelectionShares: 3
 		Units: 4tnk
-		ValidFactions: soviet
+		ValidFactions: soviet, russia, ukraine
 	GiveUnitCrateAction@mgg:
 		SelectionShares: 2
 		Units: mgg
-		ValidFactions: allies
+		ValidFactions: allies, england, germany, france, spain, greece, turkey
 	GiveUnitCrateAction@squad1:
 		SelectionShares: 2
 		Units: e1,e1,e1,e1,e1

--- a/mods/raclassic/rules/player.yaml
+++ b/mods/raclassic/rules/player.yaml
@@ -102,3 +102,33 @@ Player:
 	EnemyWatcher:
 	ResourceStorageWarning:
 	PlayerExperience:
+	ProvidesPrerequisite@Russia:
+		Factions: russia
+		Prerequisite: player.russia
+	ProvidesPrerequisite@Turkey:
+		Factions: turkey
+		Prerequisite: player.turkey
+	ProvidesPrerequisite@Normal:
+		Factions: allies, england, germany, france, spain, greece, soviet, ukraine
+		Prerequisite: player.normal
+	ProvidesPrerequisite@Normal_power:
+		Factions: allies, england, germany, france, spain, soviet, ukraine
+		Prerequisite: player.normal_power
+	ProvidesPrerequisite@England:
+		Factions: england
+		Prerequisite: player.england
+	ProvidesPrerequisite@Germany:
+		Factions: germany
+		Prerequisite: player.germany
+	ProvidesPrerequisite@France:
+		Factions: france
+		Prerequisite: player.france
+	ProvidesPrerequisite@Spain:
+		Factions: spain
+		Prerequisite: player.spain
+	ProvidesPrerequisite@Greece:
+		Factions: greece
+		Prerequisite: player.greece
+	ProvidesPrerequisite@Ukraine:
+		Factions: ukraine
+		Prerequisite: player.ukraine

--- a/mods/raclassic/rules/ships.yaml
+++ b/mods/raclassic/rules/ships.yaml
@@ -1,11 +1,15 @@
 SS:
 	Inherits: ^Ship
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 111
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Submarine
+		BuildDuration: 950
 		BuildPaletteOrder: 30
-		Prerequisites: ~spen, ~techlevel.3
+		Prerequisites: ~spen, ~player.normal, ~techlevel.3
 		Description: Submerged anti-ship unit\narmed with torpedoes.\nCan detect other submarines.\n  Strong vs Naval units\n  Weak vs Ground units, Aircraft\n  Special Ability: Submerge
 	Valued:
 		Cost: 950
@@ -59,16 +63,23 @@ SS:
 		EmptyWeapon: UnitExplodeSubmarine
 	-MustBeDestroyed:
 	Selectable:
+		Class: SS
 		DecorationBounds: 38,38
+	RenderSprites:
+		Image: SS
 
 MSUB:
 	Inherits: ^Ship
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 107
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Submarine
+		BuildDuration: 1650
 		BuildPaletteOrder: 60
-		Prerequisites: ~spen, stek, ~global-aftermath, ~techlevel.6
+		Prerequisites: ~spen, stek, ~global-aftermath, ~player.normal, ~techlevel.6
 		Description: Submerged anti-ground siege unit.\nCan detect other submarines.\n  Strong vs Buildings, Ground units, Aircraft\n  Weak vs Naval units\n  Special Ability: Submerge
 	Valued:
 		Cost: 1650
@@ -118,7 +129,10 @@ MSUB:
 		EmptyWeapon: UnitExplodeSubmarine
 	-MustBeDestroyed:
 	Selectable:
+		Class: MSUB
 		DecorationBounds: 44,44
+	RenderSprites:
+		Image: MSUB
 
 DD:
 	Inherits: ^Ship
@@ -126,8 +140,9 @@ DD:
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Boat
+		BuildDuration: 1000
 		BuildPaletteOrder: 40
-		Prerequisites: ~syrd, dome, ~techlevel.5
+		Prerequisites: ~syrd, dome, ~player.normal, ~techlevel.5
 		Description: Fast multi-role ship.\nCan detect submarines.\n  Strong vs Naval units, Light armor, Aircraft\n  Weak vs Infantry, Tanks
 	Valued:
 		Cost: 1000
@@ -149,14 +164,32 @@ DD:
 		Weapon: Stinger
 		LocalOffset: 0,-100,0, 0,100,0
 		LocalYaw: 64, -64
+		RequiresCondition: !spain
 	Armament@SECONDARY:
 		Weapon: DepthCharge
 		LocalOffset: 0,-100,0, 0,100,0
 		LocalYaw: 80, -80
+		RequiresCondition: !spain
 	Armament@TERTIARY:
 		Weapon: StingerAA
 		LocalOffset: 0,-100,0, 0,100,0
 		LocalYaw: 64, -64
+		RequiresCondition: !spain
+	Armament@PRIMARY_SPAIN:
+		Weapon: Stinger.spain
+		LocalOffset: 0,-100,0, 0,100,0
+		LocalYaw: 64, -64
+		RequiresCondition: spain
+	Armament@SECONDARY_SPAIN:
+		Weapon: DepthCharge.spain
+		LocalOffset: 0,-100,0, 0,100,0
+		LocalYaw: 80, -80
+		RequiresCondition: spain
+	Armament@TERTIARY_SPAIN:
+		Weapon: StingerAA.spain
+		LocalOffset: 0,-100,0, 0,100,0
+		LocalYaw: 64, -64
+		RequiresCondition: spain
 	AttackTurreted:
 	SelectionDecorations:
 	WithSpriteTurret:
@@ -165,17 +198,23 @@ DD:
 		Range: 4c0
 	RenderDetectionCircle:
 	Selectable:
+		Class: DD
 		DecorationBounds: 38,38
+	RenderSprites:
+		Image: DD
 
 CA:
 	Inherits: ^Ship
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 105
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Boat
-		BuildPaletteOrder: 50
-		Prerequisites: ~syrd, atek, ~techlevel.7
 		BuildDuration: 2000
+		BuildPaletteOrder: 50
+		Prerequisites: ~syrd, atek, ~player.normal, ~techlevel.7
 		Description: Very slow long-range ship.\n  Strong vs Buildings, Ground units\n  Weak vs Naval units, Aircraft
 	Valued:
 		Cost: 2000
@@ -223,14 +262,18 @@ CA:
 	WithSpriteTurret@SECONDARY:
 		Turret: secondary
 	Selectable:
+		Class: CA
 		DecorationBounds: 44,44
+	RenderSprites:
+		Image: CA
 
 LST:
 	Inherits: ^Ship
 	Buildable:
 		Queue: Ship
+		BuildDuration: 700
 		BuildPaletteOrder: 10
-		Prerequisites: ~techlevel.2
+		Prerequisites: ~player.normal, ~techlevel.2
 		Description: General-purpose naval transport.\nCan carry infantry and tanks.\n  Unarmed
 	Valued:
 		Cost: 700
@@ -257,16 +300,20 @@ LST:
 		LoadingCondition: notmobile
 	-Chronoshiftable:
 	Selectable:
+		Class: LST
 		DecorationBounds: 36,36
+	RenderSprites:
+		Image: LST
 
 PT:
 	Inherits: ^Ship
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Buildable:
 		Queue: Ship
+		BuildDuration: 500
 		BuildAtProductionType: Boat
 		BuildPaletteOrder: 20
-		Prerequisites: ~syrd, ~techlevel.3
+		Prerequisites: ~syrd, ~player.normal, ~techlevel.3
 		Description: Light scout & support ship.\nCan detect submarines.\n  Strong vs Naval units\n  Weak vs Ground units, Aircraft
 	Valued:
 		Cost: 500
@@ -288,10 +335,22 @@ PT:
 		Weapon: 2Inch
 		LocalOffset: 208,0,48
 		MuzzleSequence: muzzle
+		RequiresCondition: !spain
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: DepthCharge
 		MuzzleSequence: muzzle
+		RequiresCondition: !spain
+	Armament@PRIMARY_SPAIN:
+		Weapon: 2Inch.spain
+		LocalOffset: 208,0,48
+		MuzzleSequence: muzzle
+		RequiresCondition: spain
+	Armament@SECONDARY_SPAIN:
+		Name: secondary
+		Weapon: DepthCharge.spain
+		MuzzleSequence: muzzle
+		RequiresCondition: spain
 	AttackTurreted:
 	WithMuzzleOverlay:
 	SelectionDecorations:
@@ -301,4 +360,7 @@ PT:
 		Range: 4c0
 	RenderDetectionCircle:
 	Selectable:
+		Class: PT
 		DecorationBounds: 36,36
+	RenderSprites:
+		Image: PT

--- a/mods/raclassic/rules/structures.yaml
+++ b/mods/raclassic/rules/structures.yaml
@@ -8,8 +8,9 @@ MSLO:
 		Name: Missile Silo
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 200
-		Prerequisites: techcenter, ~techlevel.10
+		BuildDuration: 2500
+		BuildPaletteOrder: 300
+		Prerequisites: techcenter, ~player.normal, ~techlevel.10
 		BuildLimit: 1
 		Description: Provides an atomic bomb.\nRequires power to operate.\n  Special Ability: Atom Bomb\nMaximum 1 can be built.
 	Building:
@@ -46,11 +47,16 @@ MSLO:
 		CircleSequence: circles
 	SupportPowerChargeBar:
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: mslo
 	Power:
 		Amount: -100
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	WithNukeLaunchAnimation:
+	Selectable:
+		Class: MSLO
+	RenderSprites:
+		Image: MSLO
 
 GAP:
 	Inherits: ^Building
@@ -61,10 +67,12 @@ GAP:
 		Name: Gap Generator
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 170
-		Prerequisites: atek, ~structures.allies, ~techlevel.7
+		BuildDuration: 500
+		BuildPaletteOrder: 240
+		Prerequisites: atek, ~structures.allies, ~player.normal, ~techlevel.7
 		Description: Obscures the enemy's view with shroud.\nRequires power to operate.
 	Selectable:
+		Class: GAP
 		Bounds: 24,24
 		DecorationBounds: 24,48,0,-12
 	SelectionDecorations:
@@ -88,6 +96,8 @@ GAP:
 		Type: Rectangle
 			TopLeft: -512, -512
 			BottomRight: 512, 512
+	RenderSprites:
+		Image: GAP
 
 SPEN:
 	Inherits: ^Building
@@ -99,8 +109,9 @@ SPEN:
 		Name: Sub Pen
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 70
-		Prerequisites: anypower, ~structures.soviet, ~techlevel.2
+		BuildDuration: 650
+		BuildPaletteOrder: 100
+		Prerequisites: anypower, ~structures.soviet, ~player.normal, ~techlevel.2
 		Description: Produces and repairs\nsubmarines and transports.
 	Targetable:
 		TargetTypes: Ground, Water, Structure, WaterStructure, C4, DetonateAttack, SpyInfiltrate
@@ -144,12 +155,13 @@ SPEN:
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@soviet:
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		Prerequisite: ships.soviet
 	ProvidesPrerequisite@sovietstructure:
 		RequiresPrerequisites: structures.soviet
 		Prerequisite: ships.soviet
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: spen
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
 	WithDecoration@primary:
@@ -170,6 +182,10 @@ SPEN:
 			BottomRight: 555, 1110
 	RequiresBuildableArea:
 		Adjacent: 8
+	Selectable:
+		Class: SPEN
+	RenderSprites:
+		Image: SPEN
 
 SYRD:
 	Inherits: ^Building
@@ -177,8 +193,9 @@ SYRD:
 		Proxy: powerproxy.sonarpulse
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 70
-		Prerequisites: anypower, ~structures.allies, ~techlevel.2
+		BuildDuration: 650
+		BuildPaletteOrder: 90
+		Prerequisites: anypower, ~structures.allies, ~player.normal, ~techlevel.2
 		Description: Produces and repairs ships\nand transports.
 	Valued:
 		Cost: 650
@@ -226,12 +243,13 @@ SYRD:
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@allies:
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		Prerequisite: ships.allies
 	ProvidesPrerequisite@alliedstructure:
 		RequiresPrerequisites: structures.allies
 		Prerequisite: ships.allies
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: syrd
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
 	WithDecoration@primary:
@@ -253,6 +271,10 @@ SYRD:
 			BottomRight: 512, 1110
 	RequiresBuildableArea:
 		Adjacent: 8
+	Selectable:
+		Class: SYRD
+	RenderSprites:
+		Image: SYRD
 
 IRON:
 	Inherits: ^Building
@@ -260,8 +282,9 @@ IRON:
 	Inherits@shape: ^2x1Shape
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 190
-		Prerequisites: stek, ~structures.soviet, ~techlevel.9
+		BuildDuration: 2800
+		BuildPaletteOrder: 290
+		Prerequisites: stek, ~structures.soviet, ~player.normal, ~techlevel.9
 		BuildLimit: 1
 		Description: Makes a unit invulnerable\nfor a while.\nRequires power to operate.\n  Special Ability: Invulnerability\nMaximum 1 can be built.
 	Valued:
@@ -301,6 +324,10 @@ IRON:
 		Amount: -200
 	MustBeDestroyed:
 		RequiredForShortGame: false
+	Selectable:
+		Class: IRON
+	RenderSprites:
+		Image: IRON
 
 PDOX:
 	Inherits: ^Building
@@ -308,8 +335,9 @@ PDOX:
 	Inherits@shape: ^2x2Shape
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 190
-		Prerequisites: atek, ~structures.allies, ~techlevel.9
+		BuildDuration: 2800
+		BuildPaletteOrder: 280
+		Prerequisites: atek, ~structures.allies, ~player.normal, ~techlevel.9
 		BuildLimit: 1
 		Description: Teleports a unit across the\nmap for a short time.\nRequires power to operate.\n  Special Ability: Chronoshift\nMaximum 1 can be built.
 	Valued:
@@ -345,22 +373,30 @@ PDOX:
 		Amount: -200
 	MustBeDestroyed:
 		RequiredForShortGame: false
-	ProvidesPrerequisite@buildingname:
+	Selectable:
+		Class: PDOX
+	RenderSprites:
+		Image: PDOX
 
 TSLA:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisableOnLowPower
 	Inherits@AUTOTARGET: ^AutoTargetGround
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 112
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 150
-		Prerequisites: weap, ~structures.soviet, ~techlevel.5
+		BuildDuration: 1500
+		BuildPaletteOrder: 210
+		Prerequisites: weap, ~structures.soviet, ~player.normal, ~techlevel.5
 		Description: Advanced base defense.\nRequires power to operate.\nCan detect cloaked units.\n  Strong vs Vehicles, Infantry\n  Weak vs Aircraft
 	Valued:
 		Cost: 1500
 	Tooltip:
 		Name: Tesla Coil
 	Selectable:
+		Class: TSLA
 		Bounds: 24,24
 		DecorationBounds: 24,40,0,-8
 	SelectionDecorations:
@@ -384,21 +420,29 @@ TSLA:
 	DetectCloaked:
 		Range: 6c0
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: tsla
+	RenderSprites:
+		Image: TSLA
 
 AGUN:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisableOnLowPower
 	Inherits@AUTOTARGET: ^AutoTargetAir
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 117
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 180
-		Prerequisites: dome, ~structures.allies, ~techlevel.3
+		BuildDuration: 600
+		BuildPaletteOrder: 260
+		Prerequisites: dome, ~structures.allies, ~player.normal, ~techlevel.3
 		Description: Anti-Air base defense.\nRequires power to operate.\nCan detect cloaked units.\n  Strong vs Aircraft\n  Weak vs Ground units
 	Valued:
 		Cost: 600
 	Tooltip:
 		Name: AA Gun
 	Selectable:
+		Class: AGUN
 		Bounds: 24,24
 		DecorationBounds: 24,32,0,-4
 	SelectionDecorations:
@@ -426,6 +470,8 @@ AGUN:
 		Amount: -50
 	BodyOrientation:
 		UseClassicFacingFudge: True
+	RenderSprites:
+		Image: AGUN
 
 DOME:
 	Inherits: ^Building
@@ -436,8 +482,9 @@ DOME:
 		TargetableOffsets: 0,0,0, 630,-384,0, 630,384,0, -700,-512,0, -700,512,0
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 110
-		Prerequisites: proc, ~techlevel.2
+		BuildDuration: 1000
+		BuildPaletteOrder: 150
+		Prerequisites: proc, ~player.normal, ~techlevel.2
 		Description: Provides an overview\nof the battlefield.\nCan detect cloaked units.\n  Requires power to operate.
 	Valued:
 		Cost: 1000
@@ -462,19 +509,28 @@ DOME:
 	Power:
 		Amount: -40
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: dome
 	ExternalCondition@JAMMED:
 		Condition: jammed
+	Selectable:
+		Class: DOME
+	RenderSprites:
+		Image: DOME
 
 PBOX:
 	Inherits: ^Defense
 	Inherits@AUTOTARGET: ^AutoTargetAll
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 120
 	Tooltip:
 		Name: Pillbox
 	Building:
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 90
-		Prerequisites: tent, ~structures.allies, ~techlevel.1
+		BuildDuration: 400
+		BuildPaletteOrder: 120
+		Prerequisites: tent, ~structures.allies, ~player.normal, ~techlevel.1
 		Description: Static defense with a heavy machine gun.\nCan detect cloaked units.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft
 	Valued:
 		Cost: 400
@@ -501,17 +557,25 @@ PBOX:
 		Amount: -15
 	DetectCloaked:
 		Range: 5c0
+	Selectable:
+		Class: PBOX
+	RenderSprites:
+		Image: PBOX
 
 HBOX:
 	Inherits: ^Defense
 	Inherits@AUTOTARGET: ^AutoTargetAll
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 120
 	Tooltip:
 		Name: Camo Pillbox
 	Building:
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 120
-		Prerequisites: tent, ~structures.allies, ~techlevel.2
+		BuildDuration: 600
+		BuildPaletteOrder: 160
+		Prerequisites: tent, ~structures.allies, ~player.normal, ~techlevel.2
 		Description: Camouflaged static defense with a heavy machine gun.\nCan detect cloaked units.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft
 	Valued:
 		Cost: 600
@@ -539,14 +603,22 @@ HBOX:
 	Power:
 		Amount: -15
 	-MustBeDestroyed:
+	Selectable:
+		Class: HBOX
+	RenderSprites:
+		Image: HBOX
 
 GUN:
 	Inherits: ^Defense
 	Inherits@AUTOTARGET: ^AutoTargetGround
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 117
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 150
-		Prerequisites: tent, ~structures.allies, ~techlevel.2
+		BuildDuration: 800
+		BuildPaletteOrder: 200
+		Prerequisites: tent, ~structures.allies, ~player.normal, ~techlevel.2
 		Description: Anti-Armor base defense.\nCan detect cloaked units.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Valued:
 		Cost: 800
@@ -576,14 +648,22 @@ GUN:
 		Range: 6c0
 	BodyOrientation:
 		UseClassicFacingFudge: True
+	Selectable:
+		Class: GUN
+	RenderSprites:
+		Image: GUN
 
 FTUR:
 	Inherits: ^Defense
 	Inherits@AUTOTARGET: ^AutoTargetGround
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 120
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 90
-		Prerequisites: barr, ~structures.soviet, ~techlevel.1
+		BuildDuration: 600
+		BuildPaletteOrder: 130
+		Prerequisites: barr, ~structures.soviet, ~player.normal, ~techlevel.1
 		Description: Anti-Infantry base defense.\nCan detect cloaked units.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft
 	Valued:
 		Cost: 600
@@ -610,7 +690,10 @@ FTUR:
 		Amount: -20
 	DetectCloaked:
 		Range: 6c0
-	ProvidesPrerequisite@buildingname:
+	Selectable:
+		Class: FTUR
+	RenderSprites:
+		Image: FTUR
 
 SAM:
 	Inherits: ^Defense
@@ -620,10 +703,14 @@ SAM:
 		Type: Rectangle
 			TopLeft: -768,-512
 			BottomRight: 768,512
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 113
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 180
-		Prerequisites: dome, ~structures.soviet, ~techlevel.6
+		BuildDuration: 750
+		BuildPaletteOrder: 270
+		Prerequisites: dome, ~structures.soviet, ~player.normal, ~techlevel.6
 		Description: Anti-Air base defense.\nCan detect cloaked units.\n  Strong vs Aircraft\n  Weak vs Ground units
 	Valued:
 		Cost: 750
@@ -655,6 +742,10 @@ SAM:
 		Amount: -20
 	BodyOrientation:
 		UseClassicFacingFudge: True
+	Selectable:
+		Class: SAM
+	RenderSprites:
+		Image: SAM
 
 ATEK:
 	Inherits: ^Building
@@ -662,8 +753,9 @@ ATEK:
 	Inherits@shape: ^2x2Shape
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 160
-		Prerequisites: weap, dome, ~structures.allies, ~techlevel.7
+		BuildDuration: 1500
+		BuildPaletteOrder: 220
+		Prerequisites: weap, dome, ~structures.allies, ~player.normal, ~techlevel.7
 		Description: Provides Allied advanced technologies.\n  Special Ability: GPS Satellite
 	Valued:
 		Cost: 1500
@@ -696,14 +788,20 @@ ATEK:
 	Power:
 		Amount: -200
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: atek
+	Selectable:
+		Class: ATEK
+	RenderSprites:
+		Image: ATEK
 
 WEAP:
 	Inherits: ^Building
 	Inherits@shape: ^3x2Shape
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 100
-		Prerequisites: proc, ~techlevel.2
+		BuildDuration: 2000
+		BuildPaletteOrder: 140
+		Prerequisites: proc, ~player.normal, ~techlevel.2
 		Description: Produces vehicles.
 	Valued:
 		Cost: 2000
@@ -728,10 +826,10 @@ WEAP:
 	Production:
 		Produces: Vehicle
 	ProvidesPrerequisite@allies:
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		Prerequisite: vehicles.allies
 	ProvidesPrerequisite@soviet:
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		Prerequisite: vehicles.soviet
 	ProvidesPrerequisite@alliedstructure:
 		RequiresPrerequisites: structures.allies
@@ -745,6 +843,7 @@ WEAP:
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: weap
 	Targetable:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 	InfiltrateForSupportPower:
@@ -756,6 +855,10 @@ WEAP:
 		ReferencePoint: Top
 		ZOffset: 256
 		RequiresCondition: primary
+	Selectable:
+		Class: WEAP
+	RenderSprites:
+		Image: WEAP
 
 FACT:
 	Inherits: ^Building
@@ -765,14 +868,15 @@ FACT:
 		LocalCenterOffset: 0,-512,0
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 1000
+		BuildDuration: 2500
+		BuildPaletteOrder: 0
 		Prerequisites: ~disabled
 		Description: Produces structures.
 	ProvidesPrerequisite@allies:
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		Prerequisite: structures.allies
 	ProvidesPrerequisite@soviet:
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		Prerequisite: structures.soviet
 	Health:
 		HP: 1000
@@ -804,18 +908,24 @@ FACT:
 	Power:
 		Amount: 0
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: fact
 	HitShape:
 		TargetableOffsets: 1273,939,0, -980,-640,0, -980,640,0
 		Type: Rectangle
 			TopLeft: -1536, -1536
 			BottomRight: 1536, 1536
+	Selectable:
+		Class: FACT
+	RenderSprites:
+		Image: FACT
 
 PROC:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 50
-		Prerequisites: anypower, ~techlevel.1
+		BuildDuration: 2000
+		BuildPaletteOrder: 70
+		Prerequisites: anypower, ~player.normal, ~techlevel.1
 		Description: Refines Ore and Gems\ninto credits.
 	Valued:
 		Cost: 2000
@@ -826,6 +936,7 @@ PROC:
 		Dimensions: 3,4
 		LocalCenterOffset: 0,-512,0
 	Selectable:
+		Class: PROC
 		Bounds: 72,50,0,12
 		DecorationBounds: 72,70,0,-2
 	SelectionDecorations:
@@ -859,6 +970,7 @@ PROC:
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: proc
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -512
@@ -873,13 +985,16 @@ PROC:
 		Type: Rectangle
 			TopLeft: -1536, 598
 			BottomRight: -512, 1280
+	RenderSprites:
+		Image: PROC
 
 SILO:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 80
-		Prerequisites: proc, ~techlevel.1
+		BuildDuration: 150
+		BuildPaletteOrder: 110
+		Prerequisites: proc, ~player.normal, ~techlevel.1
 		Description: Stores excess refined\nOre and Gems.
 	Valued:
 		Cost: 150
@@ -904,6 +1019,10 @@ SILO:
 	-EmitInfantryOnSell:
 	Power:
 		Amount: -10
+	Selectable:
+		Class: SILO
+	RenderSprites:
+		Image: SILO
 
 HPAD:
 	Inherits: ^Building
@@ -913,8 +1032,9 @@ HPAD:
 		TargetableOffsets: 0,0,0, 768,-512,0, 768,512,0, -281,-512,0, -630,512,0
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 140
-		Prerequisites: dome, ~techlevel.6
+		BuildDuration: 1500
+		BuildPaletteOrder: 190
+		Prerequisites: dome, ~player.normal, ~techlevel.6
 		Description: Produces and reloads\nhelicopters.
 	Valued:
 		Cost: 1500
@@ -946,10 +1066,10 @@ HPAD:
 	Power:
 		Amount: -10
 	ProvidesPrerequisite@allies:
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		Prerequisite: heli.allies
 	ProvidesPrerequisite@soviet:
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		Prerequisite: heli.soviet
 	ProvidesPrerequisite@alliedstructure:
 		RequiresPrerequisites: structures.allies
@@ -958,6 +1078,7 @@ HPAD:
 		RequiresPrerequisites: structures.soviet
 		Prerequisite: heli.soviet
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: hpad
 	Targetable:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 	InfiltrateForSupportPower:
@@ -970,6 +1091,10 @@ HPAD:
 		ZOffset: 256
 		RequiresCondition: primary
 	WithRearmAnimation:
+	Selectable:
+		Class: HPAD
+	RenderSprites:
+		Image: HPAD
 
 AFLD:
 	Inherits: ^Building
@@ -979,8 +1104,9 @@ AFLD:
 		TargetableOffsets: 0,0,0, 420,0,0, 420,-1024,0, 420,1024,0, -777,0,0, -777,-1024,0, -777,1024,0
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 170
-		Prerequisites: dome, ~structures.soviet, ~techlevel.3
+		BuildDuration: 600
+		BuildPaletteOrder: 250
+		Prerequisites: dome, ~structures.soviet, ~player.normal, ~techlevel.3
 		Description: Produces and reloads aircraft.\n  Special Ability: Paratroopers\n  Special Ability: Spy Plane
 	Valued:
 		Cost: 600
@@ -1004,7 +1130,7 @@ AFLD:
 		Produces: Aircraft, Plane
 	Reservable:
 	ProvidesPrerequisite@soviet:
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		Prerequisite: aircraft.soviet
 	ProvidesPrerequisite@sovietstructure:
 		RequiresPrerequisites: structures.soviet
@@ -1051,6 +1177,7 @@ AFLD:
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: afld
 	Targetable:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 	InfiltrateForSupportPower:
@@ -1063,6 +1190,10 @@ AFLD:
 		ZOffset: 256
 		RequiresCondition: primary
 	WithRearmAnimation:
+	Selectable:
+		Class: AFLD
+	RenderSprites:
+		Image: AFLD
 
 POWR:
 	Inherits: ^Building
@@ -1072,8 +1203,9 @@ POWR:
 		TargetableOffsets: 0,0,0, 640,-384,0, 640,512,0, -710,-512,0, -710,512,0
 	Buildable:
 		Queue: Building
+		BuildDuration: 300
 		BuildPaletteOrder: 10
-		Prerequisites: ~techlevel.1
+		Prerequisites: ~player.normal_power, ~techlevel.1
 		Description: Provides power for other structures.
 	Valued:
 		Cost: 300
@@ -1097,6 +1229,10 @@ POWR:
 	Targetable:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
 	ScalePowerWithHealth:
+	Selectable:
+		Class: POWR
+	RenderSprites:
+		Image: POWR
 
 APWR:
 	Inherits: ^Building
@@ -1105,8 +1241,9 @@ APWR:
 		TargetableOffsets: -355,-1024,0
 	Buildable:
 		Queue: Building
+		BuildDuration: 500
 		BuildPaletteOrder: 20
-		Prerequisites: anypower, ~techlevel.5
+		Prerequisites: anypower, ~player.normal_power, ~techlevel.5
 		Description: Provides double the power of a\nstandard Power Plant.
 	Valued:
 		Cost: 500
@@ -1134,6 +1271,10 @@ APWR:
 	Targetable:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
 	ScalePowerWithHealth:
+	Selectable:
+		Class: APWR
+	RenderSprites:
+		Image: APWR
 
 STEK:
 	Inherits: ^Building
@@ -1142,8 +1283,9 @@ STEK:
 		TargetableOffsets: 420,-768,0, 420,768,0, -770,-768,0, -770,768,0
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 160
-		Prerequisites: weap, dome, ~structures.soviet, ~techlevel.4
+		BuildDuration: 1500
+		BuildPaletteOrder: 230
+		Prerequisites: weap, dome, ~structures.soviet, ~player.normal, ~techlevel.4
 		Description: Provides Soviet advanced technologies.
 	Valued:
 		Cost: 1500
@@ -1165,6 +1307,11 @@ STEK:
 	Power:
 		Amount: -100
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: stek
+	Selectable:
+		Class: STEK
+	RenderSprites:
+		Image: STEK
 
 BARR:
 	Inherits: ^Building
@@ -1174,8 +1321,9 @@ BARR:
 		TargetableOffsets: 0,0,0, 490,-470,0, 355,512,0, -355,-512,0, -630,512,0
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 40
-		Prerequisites: anypower, ~structures.soviet, ~techlevel.1
+		BuildDuration: 300
+		BuildPaletteOrder: 60
+		Prerequisites: anypower, ~structures.soviet, ~player.normal, ~techlevel.1
 		Description: Trains infantry.
 	Valued:
 		Cost: 300
@@ -1207,7 +1355,7 @@ BARR:
 	ProvidesPrerequisite:
 		Prerequisite: barracks
 	ProvidesPrerequisite@soviet:
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		Prerequisite: infantry.soviet
 	ProvidesPrerequisite@sovietstructure:
 		RequiresPrerequisites: structures.soviet
@@ -1215,6 +1363,7 @@ BARR:
 	Power:
 		Amount: -20
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: barr
 	InfiltrateForSupportPower:
 		Proxy: barracks.upgraded
 	Targetable:
@@ -1226,13 +1375,18 @@ BARR:
 		ReferencePoint: Top
 		ZOffset: 256
 		RequiresCondition: primary
+	Selectable:
+		Class: BARR
+	RenderSprites:
+		Image: BARR
 
 KENN:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 120
-		Prerequisites: barr, ~structures.soviet, ~techlevel.2
+		BuildDuration: 200
+		BuildPaletteOrder: 170
+		Prerequisites: barr, ~structures.soviet, ~player.normal, ~techlevel.2
 		Description: Trains Attack Dogs.
 	Valued:
 		Cost: 200
@@ -1261,6 +1415,7 @@ KENN:
 	Power:
 		Amount: -10
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: kenn
 	WithDecoration@primary:
 		RequiresSelection: true
 		Image: pips
@@ -1268,6 +1423,10 @@ KENN:
 		ReferencePoint: Top
 		ZOffset: 256
 		RequiresCondition: primary
+	Selectable:
+		Class: KENN
+	RenderSprites:
+		Image: KENN
 
 TENT:
 	Inherits: ^Building
@@ -1277,8 +1436,9 @@ TENT:
 		TargetableOffsets: 0,0,0, 630,-512,0, 355,512,0, -281,-512,0, -630,512,0
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 40
-		Prerequisites: anypower, ~structures.allies, ~techlevel.1
+		BuildDuration: 300
+		BuildPaletteOrder: 50
+		Prerequisites: anypower, ~structures.allies, ~player.normal, ~techlevel.1
 		Description: Trains infantry.
 	Valued:
 		Cost: 300
@@ -1310,7 +1470,7 @@ TENT:
 	ProvidesPrerequisite@barracks:
 		Prerequisite: barracks
 	ProvidesPrerequisite@allies:
-		Factions: allies, england, france, germany
+		Factions: allies, england, germany, france, spain, greece, turkey
 		Prerequisite: infantry.allies
 	ProvidesPrerequisite@alliedstructure:
 		RequiresPrerequisites: structures.allies
@@ -1318,6 +1478,7 @@ TENT:
 	Power:
 		Amount: -20
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: tent
 	InfiltrateForSupportPower:
 		Proxy: barracks.upgraded
 	Targetable:
@@ -1329,13 +1490,18 @@ TENT:
 		ReferencePoint: Top
 		ZOffset: 256
 		RequiresCondition: primary
+	Selectable:
+		Class: TENT
+	RenderSprites:
+		Image: TENT
 
 FIX:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 130
-		Prerequisites: weap, ~techlevel.2
+		BuildDuration: 1200
+		BuildPaletteOrder: 180
+		Prerequisites: weap, ~player.normal, ~techlevel.2
 		Description: Repairs vehicles for credits.
 	Valued:
 		Cost: 1200
@@ -1345,6 +1511,7 @@ FIX:
 		Footprint: _=_ xxx _=_
 		Dimensions: 3,3
 	Selectable:
+		Class: FIX
 		Bounds: 68,34,0,3
 		DecorationBounds: 72,48
 	SelectionDecorations:
@@ -1372,6 +1539,7 @@ FIX:
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
+		Prerequisite: fix
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -683
@@ -1381,13 +1549,16 @@ FIX:
 		Type: Rectangle
 			TopLeft: -640, -768
 			BottomRight: 640, 1024
+	RenderSprites:
+		Image: FIX
 
 SBAG:
 	Inherits: ^Wall
 	Buildable:
 		Queue: Building
+		BuildDuration: 25
 		BuildPaletteOrder: 30
-		Prerequisites: fact, ~structures.allies, ~techlevel.1
+		Prerequisites: fact, ~structures.allies, ~player.normal, ~techlevel.1
 		Description: Stops infantry and light vehicles.\nCan be crushed by tanks.
 	Valued:
 		Cost: 25
@@ -1406,13 +1577,16 @@ SBAG:
 		Types: sandbag
 	WithWallSpriteBody:
 		Type: sandbag
+	RenderSprites:
+		Image: SBAG
 
 FENC:
 	Inherits: ^Wall
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 30
-		Prerequisites: fact, ~structures.soviet, ~techlevel.1
+		BuildDuration: 25
+		BuildPaletteOrder: 40
+		Prerequisites: fact, ~structures.soviet, ~player.normal, ~techlevel.1
 		Description: Stops infantry and light vehicles.\nCan be crushed by tanks.
 	Valued:
 		Cost: 25
@@ -1431,13 +1605,16 @@ FENC:
 		Types: fence
 	WithWallSpriteBody:
 		Type: fence
+	RenderSprites:
+		Image: FENC
 
 BRIK:
 	Inherits: ^Wall
 	Buildable:
 		Queue: Building
-		BuildPaletteOrder: 60
-		Prerequisites: fact, ~techlevel.5
+		BuildDuration: 50
+		BuildPaletteOrder: 80
+		Prerequisites: fact, ~player.normal, ~techlevel.5
 		Description: Stop units and blocks enemy fire.
 	Valued:
 		Cost: 50
@@ -1462,6 +1639,8 @@ BRIK:
 		Types: concrete
 	WithWallSpriteBody:
 		Type: concrete
+	RenderSprites:
+		Image: BRIK
 
 VGATE:
 	Inherits: ^Gate

--- a/mods/raclassic/rules/vehicles.yaml
+++ b/mods/raclassic/rules/vehicles.yaml
@@ -3,10 +3,14 @@ V2RL:
 	Inherits@TRACK: ^TrackedVehicle
 	Inherits@CRUSH: ^CrusherVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 110
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 50
-		Prerequisites: dome, ~vehicles.soviet, ~techlevel.2
+		BuildDuration: 700
+		BuildPaletteOrder: 70
+		Prerequisites: dome, ~vehicles.soviet, ~player.normal, ~techlevel.2
 		Description: Long-range rocket artillery.\n  Strong vs Infantry, Light armor, Buildings\n  Weak vs Tanks, Aircraft
 	Valued:
 		Cost: 700
@@ -40,17 +44,24 @@ V2RL:
 	Explodes:
 		Weapon: V2Explode
 	Selectable:
+		Class: V2RL
 		DecorationBounds: 28,28
+	RenderSprites:
+		Image: V2RL
 
 1TNK:
 	Inherits: ^Tank
 	Inherits@TRACK: ^TrackedVehicle
 	Inherits@CRUSH: ^CrusherVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 125
 	Buildable:
 		Queue: Vehicle
+		BuildDuration: 700
 		BuildPaletteOrder: 30
-		Prerequisites: ~vehicles.allies, ~techlevel.2
+		Prerequisites: ~vehicles.allies, ~player.normal, ~techlevel.2
 		Description: Light Tank, good for scouting.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
 	Valued:
 		Cost: 700
@@ -77,16 +88,24 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 1TNK.Husk
+	Selectable:
+		Class: 1TNK
+	RenderSprites:
+		Image: 1TNK
 
 2TNK:
 	Inherits: ^Tank
 	Inherits@TRACK: ^TrackedVehicle
 	Inherits@CRUSH: ^CrusherVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 121
 	Buildable:
 		Queue: Vehicle
+		BuildDuration: 800
 		BuildPaletteOrder: 40
-		Prerequisites: ~vehicles.allies, ~techlevel.4
+		Prerequisites: ~vehicles.allies, ~player.normal, ~techlevel.4
 		Description: Allied Main Battle Tank.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Valued:
 		Cost: 800
@@ -115,17 +134,24 @@ V2RL:
 		Actor: 2TNK.Husk
 	SelectionDecorations:
 	Selectable:
+		Class: 2TNK
 		DecorationBounds: 28,28
+	RenderSprites:
+		Image: 2TNK
 
 3TNK:
 	Inherits: ^Tank
 	Inherits@TRACK: ^TrackedVehicle
 	Inherits@CRUSH: ^CrusherVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 121
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 40
-		Prerequisites: ~vehicles.soviet, ~techlevel.2
+		BuildDuration: 950
+		BuildPaletteOrder: 50
+		Prerequisites: ~vehicles.soviet, ~player.normal, ~techlevel.2
 		Description: Soviet Main Battle Tank, with dual cannons\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Valued:
 		Cost: 950
@@ -154,7 +180,10 @@ V2RL:
 		Actor: 3TNK.Husk
 	SelectionDecorations:
 	Selectable:
+		Class: 3TNK
 		DecorationBounds: 28,28
+	RenderSprites:
+		Image: 3TNK
 
 4TNK:
 	Inherits: ^Tank
@@ -163,8 +192,9 @@ V2RL:
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 100
-		Prerequisites: stek, ~vehicles.soviet, ~techlevel.7
+		BuildDuration: 1700
+		BuildPaletteOrder: 140
+		Prerequisites: stek, ~vehicles.soviet, ~player.normal, ~techlevel.7
 		Description: Big and slow tank, with anti-air capability.\n  Strong vs Vehicles, Infantry, Aircraft\n  Weak vs Nothing
 	Valued:
 		Cost: 1700
@@ -186,6 +216,7 @@ V2RL:
 		Recoil: 171
 		RecoilRecovery: 30
 		MuzzleSequence: muzzle
+		RequiresCondition: !spain
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: MammothTusk
@@ -193,6 +224,22 @@ V2RL:
 		LocalYaw: -100,100
 		Recoil: 43
 		MuzzleSequence: muzzle
+		RequiresCondition: !spain
+	Armament@PRIMARY_SPAIN:
+		Weapon: 120mm.spain
+		LocalOffset: 900,180,340, 900,-180,340
+		Recoil: 171
+		RecoilRecovery: 30
+		MuzzleSequence: muzzle
+		RequiresCondition: spain
+	Armament@SECONDARY_SPAIN:
+		Name: secondary
+		Weapon: MammothTusk.spain
+		LocalOffset: -85,384,340, -85,-384,340
+		LocalYaw: -100,100
+		Recoil: 43
+		MuzzleSequence: muzzle
+		RequiresCondition: spain
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
@@ -205,16 +252,23 @@ V2RL:
 		DamageCooldown: 150
 	SelectionDecorations:
 	Selectable:
+		Class: 4TNK
 		DecorationBounds: 44,38,0,-4
+	RenderSprites:
+		Image: 4TNK
 
 ARTY:
 	Inherits: ^Tank
 	Inherits@TRACK: ^TrackedVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 117
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 50
-		Prerequisites: ~vehicles.allies, ~techlevel.5
+		BuildDuration: 600
+		BuildPaletteOrder: 60
+		Prerequisites: ~vehicles.allies, ~player.normal, ~techlevel.5
 		Description: Long-range artillery.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft
 	Valued:
 		Cost: 600
@@ -239,6 +293,10 @@ ARTY:
 		Weapon: ArtilleryExplode
 		EmptyWeapon: UnitExplodeSmall
 		LoadedChance: 75
+	Selectable:
+		Class: ARTY
+	RenderSprites:
+		Image: ARTY
 
 HARV:
 	Inherits: ^Vehicle
@@ -246,8 +304,9 @@ HARV:
 	Inherits@CRUSH: ^CrusherVehicle
 	Buildable:
 		Queue: Vehicle
+		BuildDuration: 1400
 		BuildPaletteOrder: 10
-		Prerequisites: proc, ~techlevel.1
+		Prerequisites: proc, ~player.normal, ~techlevel.1
 		Description: Collects Ore and Gems for processing.\n  Unarmed
 	Valued:
 		Cost: 1400
@@ -255,6 +314,7 @@ HARV:
 		Name: Ore Truck
 		GenericName: Harvester
 	Selectable:
+		Class: HARV
 		Priority: 7
 		DecorationBounds: 42,42
 	SelectionDecorations:
@@ -285,20 +345,24 @@ HARV:
 		Delay: 25
 		HealIfBelow: 50
 		DamageCooldown: 500
+	RenderSprites:
+		Image: HARV
 
 MCV:
 	Inherits: ^Vehicle
 	Inherits@CRUSH: ^CrusherVehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 100
-		Prerequisites: fix, ~techlevel.8
+		BuildDuration: 2500
+		BuildPaletteOrder: 130
+		Prerequisites: fix, ~player.normal, ~techlevel.8
 		Description: Deploys into another Construction Yard.\n  Unarmed
 	Valued:
 		Cost: 2500
 	Tooltip:
 		Name: Mobile Construction Vehicle
 	Selectable:
+		Class: MCV
 		Priority: 4
 		DecorationBounds: 42,42
 	SelectionDecorations:
@@ -321,14 +385,20 @@ MCV:
 	BaseBuilding:
 	SpawnActorOnDeath:
 		Actor: MCV.Husk
+	RenderSprites:
+		Image: MCV
 
 JEEP:
 	Inherits: ^Vehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 125
 	Buildable:
 		Queue: Vehicle
+		BuildDuration: 600
 		BuildPaletteOrder: 20
-		Prerequisites: ~vehicles.allies, ~techlevel.2
+		Prerequisites: ~vehicles.allies, ~player.normal, ~techlevel.2
 		Description: Fast scout & anti-infantry vehicle.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
 	Valued:
 		Cost: 600
@@ -353,16 +423,24 @@ JEEP:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
+	Selectable:
+		Class: JEEP
+	RenderSprites:
+		Image: JEEP
 
 APC:
 	Inherits: ^Tank
 	Inherits@TRACK: ^TrackedVehicle
 	Inherits@CRUSH: ^CrusherVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 125
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 60
-		Prerequisites: ~vehicles.allies, tent, ~techlevel.3
+		BuildDuration: 800
+		BuildPaletteOrder: 80
+		Prerequisites: ~vehicles.allies, tent, ~player.normal, ~techlevel.3
 		Description: Tough infantry transport.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft
 	Valued:
 		Cost: 800
@@ -392,30 +470,40 @@ APC:
 		PipCount: 5
 		LoadingCondition: notmobile
 		EjectOnDeath: true
+	Selectable:
+		Class: APC
+	RenderSprites:
+		Image: APC
 
 MNLY.AP:
 	Inherits: ^Minelayer
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 90
-		Prerequisites: ~vehicles.soviet, fix, ~techlevel.2
+		BuildDuration: 800
+		BuildPaletteOrder: 110
+		Prerequisites: ~vehicles.soviet, fix, ~player.normal, ~techlevel.2
 		Description: Lays anti-personnel mines to destroy\nunwary enemy units.\n  Unarmed
 	Tooltip:
 		Name: Minelayer (Anti-Personnel)
 	Minelayer:
 		Mine: MINP
+	Selectable:
+		Class: MNLY.AP
 
 MNLY.AV:
 	Inherits: ^Minelayer
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 90
-		Prerequisites: ~vehicles.allies, fix, ~techlevel.2
+		BuildDuration: 800
+		BuildPaletteOrder: 120
+		Prerequisites: ~vehicles.allies, fix, ~player.normal, ~techlevel.2
 		Description: Lays anti-tank mines to destroy\nunwary enemy units.\n  Unarmed
 	Tooltip:
 		Name: Minelayer (Anti-Tank)
 	Minelayer:
 		Mine: MINV
+	Selectable:
+		Class: MNLY.AV
 
 TRUK:
 	Inherits: ^Vehicle
@@ -439,8 +527,9 @@ MGG:
 	Inherits@CRUSH: ^CrusherVehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 120
-		Prerequisites: ~vehicles.allies, atek, ~techlevel.8
+		BuildDuration: 600
+		BuildPaletteOrder: 160
+		Prerequisites: ~vehicles.allies, atek, ~player.normal, ~techlevel.8
 		Description: Regenerates the shroud nearby, \nobscuring the area.\n  Unarmed
 	Valued:
 		Cost: 600
@@ -462,6 +551,10 @@ MGG:
 	RenderShroudCircle:
 	SpawnActorOnDeath:
 		Actor: MGG.Husk
+	Selectable:
+		Class: MGG
+	RenderSprites:
+		Image: MGG
 
 MRJ:
 	Inherits: ^Vehicle
@@ -473,8 +566,9 @@ MRJ:
 		Name: Mobile Radar Jammer
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 80
-		Prerequisites: ~vehicles.allies, dome, ~techlevel.9
+		BuildDuration: 600
+		BuildPaletteOrder: 90
+		Prerequisites: ~vehicles.allies, dome, ~player.normal, ~techlevel.9
 		Description: Jams nearby enemy radar domes.\n  Unarmed
 	Health:
 		HP: 110
@@ -495,16 +589,24 @@ MRJ:
 		Type: jammer
 		Range: 15c0
 		Color: 0000FF80
+	Selectable:
+		Class: MRJ
+	RenderSprites:
+		Image: MRJ
 
 TTNK:
 	Inherits: ^Tank
 	Inherits@TRACK: ^TrackedVehicle
 	Inherits@CRUSH: ^CrusherVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 114
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 70
-		Prerequisites: ~vehicles.soviet, tsla, ~global-aftermath, ~techlevel.5
+		BuildDuration: 1500
+		BuildPaletteOrder: 100
+		Prerequisites: ~vehicles.soviet, tsla, ~global-aftermath, ~player.normal, ~techlevel.5
 		Description: Tank with mounted tesla coil.\n  Strong vs Infantry, Vehicles, Buildings\n  Weak vs Aircraft
 	Valued:
 		Cost: 1500
@@ -527,14 +629,18 @@ TTNK:
 		Sequence: spinner
 	SelectionDecorations:
 	Selectable:
+		Class: TTNK
 		DecorationBounds: 30,30
+	RenderSprites:
+		Image: TTNK
 
 DTRK:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 160
-		Prerequisites: mslo, ~global-aftermath, ~techlevel.10
+		BuildDuration: 2400
+		BuildPaletteOrder: 190
+		Prerequisites: mslo, ~global-aftermath, ~player.normal, ~techlevel.10
 		Description: Demolition Truck, actively armed with\nnuclear explosives. Has very weak armor.
 	Valued:
 		Cost: 2400
@@ -557,16 +663,24 @@ DTRK:
 		RequiresCondition: invulnerability
 	Chronoshiftable:
 		ExplodeInstead: yes
+	Selectable:
+		Class: DTRK
+	RenderSprites:
+		Image: DTRK
 
 CTNK:
 	Inherits: ^Vehicle
 	Inherits@TRACK: ^TrackedVehicle
 	Inherits@CRUSH: ^CrusherVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 114
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 110
-		Prerequisites: ~vehicles.allies, atek, ~global-aftermath, ~techlevel.9
+		BuildDuration: 2400
+		BuildPaletteOrder: 150
+		Prerequisites: ~vehicles.allies, atek, ~global-aftermath, ~player.normal, ~techlevel.9
 		Description: Chrono Tank, teleports to areas within range.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft\n  Special ability: Can teleport
 	Valued:
 		Cost: 2400
@@ -593,7 +707,10 @@ CTNK:
 	PortableChrono:
 		ChargeDelay: 300
 	Selectable:
+		Class: CTNK
 		DecorationBounds: 30,30
+	RenderSprites:
+		Image: CTNK
 
 QTNK:
 	Inherits: ^Tank
@@ -601,8 +718,9 @@ QTNK:
 	Inherits@CRUSH: ^CrusherVehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 140
-		Prerequisites: ~vehicles.soviet, stek, ~global-aftermath, ~techlevel.7
+		BuildDuration: 2300
+		BuildPaletteOrder: 170
+		Prerequisites: ~vehicles.soviet, stek, ~global-aftermath, ~player.normal, ~techlevel.7
 		Description: Deals seismic damage to nearby vehicles\nand structures.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft
 	Valued:
 		Cost: 2300
@@ -621,17 +739,24 @@ QTNK:
 	Targetable:
 		TargetTypes: Ground, MADTank, Repair, Vehicle
 	Selectable:
+		Class: QTNK
 		DecorationBounds: 44,38,0,-4
+	RenderSprites:
+		Image: QTNK
 
 STNK:
 	Inherits: ^Vehicle
 	Inherits@TRACK: ^TrackedVehicle
 	Inherits@CRUSH: ^CrusherVehicle
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	RangeMultiplier@Spain:
+		RequiresCondition: spain
+		Modifier: 114
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 150
-		Prerequisites: ~vehicles.allies, atek, ~disabled
+		BuildDuration: 800
+		BuildPaletteOrder: 180
+		Prerequisites: ~vehicles.allies, atek, ~player.normal, ~disabled
 		Description: Lightly armored infantry transport\nwhich can cloak.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
 	Valued:
 		Cost: 800
@@ -680,3 +805,7 @@ STNK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
 	-MustBeDestroyed:
+	Selectable:
+		Class: STNK
+	RenderSprites:
+		Image: STNK

--- a/mods/raclassic/rules/world.yaml
+++ b/mods/raclassic/rules/world.yaml
@@ -14,15 +14,72 @@
 		UseExtendedIndex: true
 	Faction@allies:
 		Name: Allies
+		Side: Allies
 		InternalName: allies
+		Description: Allies\nGeneric Allied faction doesn't have any bonuses.
+	Faction@england:
+		Name: England
+		Side: Allies
+		InternalName: england
+		Description: England\nEngland has 10% taken damage bonus on all units and structures.
+	Faction@germany:
+		Name: Germany
+		Side: Allies
+		InternalName: germany
+		Description: Germany\nGermany has 10% dealt damage bonus on on all combat units and defenses.
+	Faction@france:
+		Name: France
+		Side: Allies
+		InternalName: france
+		Description: France\nFrance has 10% rate of fire bonus on all combat units and defenses.
+	Faction@spain:
+		Name: Spain
+		Side: Allies
+		InternalName: spain
+		Description: Spain\nSpain has +1 range bonus on all combat units and defenses.
+	Faction@greece:
+		Name: Greece
+		Side: Allies
+		InternalName: greece
+		Description: Greece\nGreece has 10% power output bonus on all power plants.
+	Faction@turkey:
+		Name: Turkey
+		Side: Allies
+		InternalName: turkey
+		Description: Turkey\nTurkey has 10% build time bonus on all units and structures.
 	Faction@soviet:
 		Name: Soviet
+		Side: Soviet
 		InternalName: soviet
+		Description: Soviet\nGeneric Soviet faction doesn't have any bonuses.
+	Faction@russia:
+		Name: Russia
+		Side: Soviet
+		InternalName: russia
+		Description: Russia\nRussia has 10% cost bonus on all units and structures.
+	Faction@ukraine:
+		Name: Ukraine
+		Side: Soviet
+		InternalName: ukraine
+		Description: Ukraine\nUkraine has 10% speed bonus on all units.
 	Faction@random:
 		Name: Any
+		Side: Random
 		InternalName: Random
-		RandomFactionMembers: allies, soviet
-		Description: Random Faction\nA random faction will be chosen when the game starts.
+		RandomFactionMembers: england, germany, france, spain, greece, turkey, russia, ukraine
+		Description: Random Country\nA random country will be chosen when the game starts.
+	Faction@randomallies:
+		Name: Allies
+		InternalName: RandomAllies
+		RandomFactionMembers: england, germany, france, spain, greece, turkey
+		Side: Random
+		Description: Random Allied Country\nA random Allied country will be chosen when the game starts.
+	Faction@randomsoviet:
+		Name: Soviet
+		InternalName: RandomSoviet
+		RandomFactionMembers: russia, ukraine
+		Side: Random
+		Description: Random Soviet Country\nA random Soviet country will be chosen when the game starts.
 	ResourceType@ore:
 		Type: Ore
 		Name: Valuable Minerals
@@ -94,12 +151,12 @@ World:
 	MPStartUnits@0:
 		Class: none
 		ClassName: 0
-		Factions: allies, soviet
+		Factions: allies, england, germany, france, spain, greece, turkey, soviet, russia, ukraine
 		BaseActor: mcv
 	MPStartUnits@1:
 		Class: 1
 		ClassName: 1
-		Factions: allies, soviet
+		Factions: allies, england, germany, france, spain, greece, turkey, soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1
 		InnerSupportRadius: 2
@@ -107,7 +164,7 @@ World:
 	MPStartUnits@2_allies:
 		Class: 2
 		ClassName: 2
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		BaseActor: mcv
 		SupportActors: e1, 1tnk, 2tnk
 		InnerSupportRadius: 3
@@ -115,7 +172,7 @@ World:
 	MPStartUnits@2_soviet:
 		Class: 2
 		ClassName: 2
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1, 3tnk
 		InnerSupportRadius: 3
@@ -123,7 +180,7 @@ World:
 	MPStartUnits@3_allies:
 		Class: 3
 		ClassName: 3
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		BaseActor: mcv
 		SupportActors: e1, 1tnk, 2tnk, apc
 		InnerSupportRadius: 3
@@ -131,7 +188,7 @@ World:
 	MPStartUnits@3_soviet:
 		Class: 3
 		ClassName: 3
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1, 3tnk, v2rl
 		InnerSupportRadius: 3
@@ -139,7 +196,7 @@ World:
 	MPStartUnits@4_allies:
 		Class: 4
 		ClassName: 4
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		BaseActor: mcv
 		SupportActors: e1, 1tnk, 2tnk, apc, e3
 		InnerSupportRadius: 3
@@ -147,7 +204,7 @@ World:
 	MPStartUnits@4_soviet:
 		Class: 4
 		ClassName: 4
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1, 3tnk, v2rl, e2
 		InnerSupportRadius: 3
@@ -155,7 +212,7 @@ World:
 	MPStartUnits@5_allies:
 		Class: 5
 		ClassName: 5
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		BaseActor: mcv
 		SupportActors: e1, 1tnk, 2tnk, apc, e3, jeep, arty
 		InnerSupportRadius: 3
@@ -163,7 +220,7 @@ World:
 	MPStartUnits@5_soviet:
 		Class: 5
 		ClassName: 5
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1, 3tnk, v2rl, e2, 3tnk
 		InnerSupportRadius: 3
@@ -171,7 +228,7 @@ World:
 	MPStartUnits@6_allies:
 		Class: 6
 		ClassName: 6
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		BaseActor: mcv
 		SupportActors: e1, 1tnk, 2tnk, apc, e3, jeep, arty, 2tnk, 2tnk
 		InnerSupportRadius: 3
@@ -179,7 +236,7 @@ World:
 	MPStartUnits@6_soviet:
 		Class: 6
 		ClassName: 6
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1, 3tnk, v2rl, e2, 3tnk, 4tnk
 		InnerSupportRadius: 3
@@ -187,7 +244,7 @@ World:
 	MPStartUnits@7_allies:
 		Class: 7
 		ClassName: 7
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		BaseActor: mcv
 		SupportActors: e1, 1tnk, 2tnk, apc, e3, jeep, arty, 2tnk, 2tnk, e3
 		InnerSupportRadius: 3
@@ -195,7 +252,7 @@ World:
 	MPStartUnits@7_soviet:
 		Class: 7
 		ClassName: 7
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1, 3tnk, v2rl, e2, 3tnk, 4tnk, e4
 		InnerSupportRadius: 3
@@ -203,7 +260,7 @@ World:
 	MPStartUnits@8_allies:
 		Class: 8
 		ClassName: 8
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		BaseActor: mcv
 		SupportActors: e1, 1tnk, 2tnk, apc, e3, jeep, arty, 2tnk, 2tnk, e3, 1tnk, 2tnk
 		InnerSupportRadius: 3
@@ -211,7 +268,7 @@ World:
 	MPStartUnits@8_soviet:
 		Class: 8
 		ClassName: 8
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1, 3tnk, v2rl, e2, 3tnk, 4tnk, e4, 3tnk
 		InnerSupportRadius: 3
@@ -219,7 +276,7 @@ World:
 	MPStartUnits@9_allies:
 		Class: 9
 		ClassName: 9
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		BaseActor: mcv
 		SupportActors: e1, 1tnk, 2tnk, apc, e3, jeep, arty, 2tnk, 2tnk, e3, 1tnk, 2tnk, apc
 		InnerSupportRadius: 3
@@ -227,7 +284,7 @@ World:
 	MPStartUnits@9_soviet:
 		Class: 9
 		ClassName: 9
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1, 3tnk, v2rl, e2, 3tnk, 4tnk, e4, 3tnk, v2rl
 		InnerSupportRadius: 3
@@ -235,7 +292,7 @@ World:
 	MPStartUnits@10_allies:
 		Class: 10
 		ClassName: 10
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		BaseActor: mcv
 		SupportActors: e1, 1tnk, 2tnk, apc, e3, jeep, arty, 2tnk, 2tnk, e3, 1tnk, 2tnk, apc, e1
 		InnerSupportRadius: 3
@@ -243,7 +300,7 @@ World:
 	MPStartUnits@10_soviet:
 		Class: 10
 		ClassName: 10
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1, 3tnk, v2rl, e2, 3tnk, 4tnk, e4, 3tnk, v2rl, e1
 		InnerSupportRadius: 3
@@ -251,7 +308,7 @@ World:
 	MPStartUnits@11_allies:
 		Class: 11
 		ClassName: 11
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		BaseActor: mcv
 		SupportActors: e1, 1tnk, 2tnk, apc, e3, jeep, arty, 2tnk, 2tnk, e3, 1tnk, 2tnk, apc, e1, jeep, arty
 		InnerSupportRadius: 3
@@ -259,7 +316,7 @@ World:
 	MPStartUnits@11_soviet:
 		Class: 11
 		ClassName: 11
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1, 3tnk, v2rl, e2, 3tnk, 4tnk, e4, 3tnk, v2rl, e1, 3tnk
 		InnerSupportRadius: 3
@@ -267,7 +324,7 @@ World:
 	MPStartUnits@12_allies:
 		Class: 12
 		ClassName: 12
-		Factions: allies
+		Factions: allies, england, germany, france, spain, greece, turkey
 		BaseActor: mcv
 		SupportActors: e1, 1tnk, 2tnk, apc, e3, jeep, arty, 2tnk, 2tnk, e3, 1tnk, 2tnk, apc, e1, jeep, arty, 2tnk, 2tnk
 		InnerSupportRadius: 3
@@ -275,7 +332,7 @@ World:
 	MPStartUnits@12_soviet:
 		Class: 12
 		ClassName: 12
-		Factions: soviet
+		Factions: soviet, russia, ukraine
 		BaseActor: mcv
 		SupportActors: e1, 3tnk, v2rl, e2, 3tnk, 4tnk, e4, 3tnk, v2rl, e1, 3tnk, 4tnk
 		InnerSupportRadius: 3

--- a/mods/raclassic/weapons/ballistics.yaml
+++ b/mods/raclassic/weapons/ballistics.yaml
@@ -68,6 +68,10 @@
 	Warhead@1Dam: SpreadDamage
 		Damage: 40
 
+120mm.spain:
+	Inherits: 120mm
+	Range: 5c768
+
 TurretGun:
 	Inherits: ^Cannon
 	ReloadDelay: 35
@@ -137,6 +141,10 @@ TurretGun:
 	Warhead@1Dam: SpreadDamage
 		Damage: 25
 
+2Inch.spain:
+	Inherits: 2Inch
+	Range: 6c512
+
 Grenade:
 	Inherits: ^Artillery
 	ReloadDelay: 60
@@ -190,3 +198,7 @@ DepthCharge:
 		Explosions: small_explosion
 		ImpactSounds: kaboom15.aud
 		ValidTargets: Submarine
+
+DepthCharge.spain:
+	Inherits: DepthCharge
+	Range: 6c0

--- a/mods/raclassic/weapons/missiles.yaml
+++ b/mods/raclassic/weapons/missiles.yaml
@@ -66,6 +66,10 @@ Maverick:
 Dragon:
 	Inherits: ^AntiGroundMissile
 
+Dragon.spain:
+	Inherits: Dragon
+	Range: 6c0
+
 Hellfire:
 	Inherits: ^AntiGroundMissile
 	ReloadDelay: 60
@@ -113,6 +117,10 @@ MammothTusk:
 		ImpactSounds: kaboom25.aud
 		ValidTargets: Air
 
+MammothTusk.spain:
+	Inherits: MammothTusk
+	Range: 6c0
+
 Nike:
 	Inherits: ^AntiAirMissile
 	ReloadDelay: 20
@@ -141,6 +149,10 @@ RedEye:
 	Inherits: Nike
 	ReloadDelay: 50
 
+RedEye.spain:
+	Inherits: RedEye
+	Range: 8c512
+
 Stinger:
 	Inherits: ^AntiGroundMissile
 	ReloadDelay: 60
@@ -163,6 +175,10 @@ Stinger:
 			Light: 75
 			Concrete: 50
 
+Stinger.spain:
+	Inherits: Stinger
+	Range: 10c0
+
 StingerAA:
 	Inherits: Stinger
 	ValidTargets: Air
@@ -172,6 +188,10 @@ StingerAA:
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion_air
 		ImpactSounds: kaboom25.aud
+
+StingerAA.spain:
+	Inherits: StingerAA
+	Range: 10c0
 
 APTusk:
 	Inherits: ^AntiGroundMissile


### PR DESCRIPTION
This differs a lot from original. Because Countries in original game was a buggy mess.

- England's Armor and France's ROF bonus was buggy in original, making them weak/fire slower. They properly get their bonuses here.
- Russia's cost bonus has a wierd calculation error. Making stuff above $300 original cost $1-4 cheaper then actual 10%. I did NOT fix that. Because i think wierd costs of Russia gives a classic feeling and is too low to do a real difference. But this cost bonus was also effecting build time in original and was most likely a bug, becuase there is [a seperate ini entry for BuildTime](https://github.com/OpenRA/raclassic/blob/master/ref/Rules.ini#L313), not sure if works or not, no vanilla faction uses it.
- Ukraine's speed bonus in original only effected ground units, it effects air units too here.
- I added Spain, Greece and Turkey, which we don't have main OpenRA RA mod.
- In original Spain, Greece and Turkey had no bonus, i gave some bonuses to them here.
- Turkey gets 10% build time bonus.
- Greece gets 10% sight bonus.
- Spain gets 10% range bonus.
- I kept original Allied and Soviet countries, they have no bonus. And "Any" does not select them, so you won't be in a disadvantage by getting them, unless you want to.

Tho, i'm not sure about bonuses of Spain and Greece, or tbh, if we want that 3 countries at all. 10% is too low for a range bonus. Greece is allied country, they have GPS and FoW is disabled by default so sight bonus don't do much, and is literally useless in late game. I think we can make them better by changing them to +1 rather than 10%, and/or replace sight bonus with 10% more power output from Power Plants, could be more useful, but want to hear other's opinions too.