### PR TITLE
Added lobby option for toggling unit husks on and off

### DIFF
--- a/mods/raclassic/rules/defaults.yaml
+++ b/mods/raclassic/rules/defaults.yaml
@@ -98,11 +98,19 @@
 		RequiresCondition: stance-attackanything || assault-move
 	AttackMove:
 		AssaultMoveScanCondition: assault-move
+		
+^GlobalHusks:
+	GrantConditionOnPrerequisite@GLOBALHUSKS:
+		Condition: global-husks
+		Prerequisites: global-husks
+	SpawnActorOnDeath:
+		RequiresCondition: global-husks
 
 ^Vehicle:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^IronCurtainable
 	Inherits@3: ^SpriteActor
+	Inherits@husks: ^GlobalHusks
 	Huntable:
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
@@ -382,6 +390,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^IronCurtainable
 	Inherits@4: ^SpriteActor
+	Inherits@husks: ^GlobalHusks
 	Huntable:
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
@@ -439,10 +448,13 @@
 	EditorTilesetFilter:
 		Categories: Aircraft
 	SpawnActorOnDeath:
-		RequiresCondition: airborne
+		RequiresCondition: airborne && global-husks
 	Explodes:
 		Weapon: UnitExplode
 		RequiresCondition: !airborne
+	Explodes@NOHUSK:
+		Weapon: UnitExplodeAir
+		RequiresCondition: airborne && !global-husks
 
 ^Helicopter:
 	Inherits: ^Plane

--- a/mods/raclassic/rules/husks.yaml
+++ b/mods/raclassic/rules/husks.yaml
@@ -1,3 +1,12 @@
+V2RL.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (V2 Rocket Launcher)
+	TransformOnCapture:
+		IntoActor: v2rl
+	RenderSprites:
+		Image: v2rl.destroyed
+
 1TNK.Husk:
 	Inherits: ^Husk
 	Tooltip:
@@ -42,6 +51,15 @@
 	RenderSprites:
 		Image: 4tnk.destroyed
 
+ARTY.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (Artillery)
+	TransformOnCapture:
+		IntoActor: arty
+	RenderSprites:
+		Image: arty.destroyed
+
 HARV.FullHusk:
 	Inherits: ^Husk
 	Tooltip:
@@ -69,6 +87,51 @@ MCV.Husk:
 	RenderSprites:
 		Image: mcvhusk
 
+JEEP.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (Ranger)
+	TransformOnCapture:
+		IntoActor: jeep
+	RenderSprites:
+		Image: jeep.destroyed
+
+APC.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (Armored Personnel Carrier)
+	TransformOnCapture:
+		IntoActor: apc
+	RenderSprites:
+		Image: apc.destroyed
+
+MNLYAP.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (Mine Layer)
+	TransformOnCapture:
+		IntoActor: mnly.ap
+	RenderSprites:
+		Image: mnly.destroyed
+
+MNLYAV.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (Mine Layer)
+	TransformOnCapture:
+		IntoActor: mnly.av
+	RenderSprites:
+		Image: mnly.destroyed
+
+TRUK.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (Supply Truck)
+	TransformOnCapture:
+		IntoActor: truk
+	RenderSprites:
+		Image: truk.destroyed
+
 MGG.Husk:
 	Inherits: ^Husk
 	Tooltip:
@@ -80,6 +143,60 @@ MGG.Husk:
 		IntoActor: mgg
 	RenderSprites:
 		Image: mgg.destroyed
+
+MRJ.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (Mobile Radar Jammer)
+	TransformOnCapture:
+		IntoActor: mrj
+	RenderSprites:
+		Image: mrj.destroyed
+
+TTNK.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (Tesla Tank)
+	TransformOnCapture:
+		IntoActor: ttnk
+	RenderSprites:
+		Image: ttnk.destroyed
+
+DTRK.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (Demolition Truck)
+	TransformOnCapture:
+		IntoActor: dtrk
+	RenderSprites:
+		Image: dtrk.destroyed
+
+CTNK.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (Chrono Tank)
+	TransformOnCapture:
+		IntoActor: ctnk
+	RenderSprites:
+		Image: ctnk.destroyed
+
+QTNK.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (M.A.D. Tank)
+	TransformOnCapture:
+		IntoActor: qtnk
+	RenderSprites:
+		Image: qtnk.destroyed
+
+STNK.Husk
+	Inherits: ^Husk
+	Tooltip:
+		Name: Husk (Phase Transport)
+	TransformOnCapture:
+		IntoActor: stnk
+	RenderSprites:
+		Image: stnk.destroyed
 
 TRAN.Husk:
 	Inherits: ^HelicopterHusk

--- a/mods/raclassic/rules/husks.yaml
+++ b/mods/raclassic/rules/husks.yaml
@@ -1,7 +1,7 @@
 V2RL.Husk
 	Inherits: ^Husk
 	Tooltip:
-		Name: Husk (V2 Rocket Launcher)
+		Name: Husk (V2 Rocket)
 	TransformOnCapture:
 		IntoActor: v2rl
 	RenderSprites:

--- a/mods/raclassic/rules/husks.yaml
+++ b/mods/raclassic/rules/husks.yaml
@@ -1,4 +1,4 @@
-V2RL.Husk
+V2RL.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (V2 Rocket)
@@ -51,7 +51,7 @@ V2RL.Husk
 	RenderSprites:
 		Image: 4tnk.destroyed
 
-ARTY.Husk
+ARTY.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Artillery)
@@ -87,7 +87,7 @@ MCV.Husk:
 	RenderSprites:
 		Image: mcvhusk
 
-JEEP.Husk
+JEEP.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Ranger)
@@ -96,7 +96,7 @@ JEEP.Husk
 	RenderSprites:
 		Image: jeep.destroyed
 
-APC.Husk
+APC.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Armored Personnel Carrier)
@@ -105,25 +105,25 @@ APC.Husk
 	RenderSprites:
 		Image: apc.destroyed
 
-MNLYAP.Husk
+MNLY.AP.Husk:
 	Inherits: ^Husk
 	Tooltip:
-		Name: Husk (Mine Layer)
+		Name: Husk (Minelayer)
 	TransformOnCapture:
 		IntoActor: mnly.ap
 	RenderSprites:
 		Image: mnly.destroyed
 
-MNLYAV.Husk
+MNLY.AV.Husk:
 	Inherits: ^Husk
 	Tooltip:
-		Name: Husk (Mine Layer)
+		Name: Husk (Minelayer)
 	TransformOnCapture:
 		IntoActor: mnly.av
 	RenderSprites:
 		Image: mnly.destroyed
 
-TRUK.Husk
+TRUK.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Supply Truck)
@@ -144,7 +144,7 @@ MGG.Husk:
 	RenderSprites:
 		Image: mgg.destroyed
 
-MRJ.Husk
+MRJ.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Mobile Radar Jammer)
@@ -155,7 +155,7 @@ MRJ.Husk
 	RenderSprites:
 		Image: mrj.destroyed
 
-TTNK.Husk
+TTNK.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Tesla Tank)
@@ -166,7 +166,7 @@ TTNK.Husk
 	RenderSprites:
 		Image: ttnk.destroyed
 
-DTRK.Husk
+DTRK.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Demolition Truck)
@@ -175,7 +175,7 @@ DTRK.Husk
 	RenderSprites:
 		Image: dtrk.destroyed
 
-CTNK.Husk
+CTNK.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Chrono Tank)
@@ -184,7 +184,7 @@ CTNK.Husk
 	RenderSprites:
 		Image: ctnk.destroyed
 
-QTNK.Husk
+QTNK.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (M.A.D. Tank)
@@ -193,7 +193,7 @@ QTNK.Husk
 	RenderSprites:
 		Image: qtnk.destroyed
 
-STNK.Husk
+STNK.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Phase Transport)

--- a/mods/raclassic/rules/husks.yaml
+++ b/mods/raclassic/rules/husks.yaml
@@ -148,6 +148,8 @@ MRJ.Husk
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Mobile Radar Jammer)
+	ThrowsParticle@spinner:
+		Anim: spinner
 	TransformOnCapture:
 		IntoActor: mrj
 	RenderSprites:
@@ -157,6 +159,8 @@ TTNK.Husk
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Tesla Tank)
+	WithIdleOverlay@spinner:
+		Sequence: spinner
 	TransformOnCapture:
 		IntoActor: ttnk
 	RenderSprites:
@@ -193,6 +197,8 @@ STNK.Husk
 	Inherits: ^Husk
 	Tooltip:
 		Name: Husk (Phase Transport)
+	ThrowsParticle@turret:
+		Anim: turret
 	TransformOnCapture:
 		IntoActor: stnk
 	RenderSprites:

--- a/mods/raclassic/rules/player.yaml
+++ b/mods/raclassic/rules/player.yaml
@@ -43,17 +43,24 @@ Player:
 	LobbyPrerequisiteCheckbox@GLOBALAFTERMATH:
 		ID: aftermath
 		Label: Aftermath Units
-		Description: Enables the units that came with Aftermath expansion.
+		Description: Enables the units that came with Aftermath expansion
 		Enabled: false
 		DisplayOrder: 6
 		Prerequisites: global-aftermath
 	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:
 		ID: factundeploy
 		Label: Redeployable MCVs
-		Description: Allow undeploying Construction Yard.
+		Description: Allow undeploying Construction Yard
 		Enabled: false
 		DisplayOrder: 7
 		Prerequisites: global-factundeploy
+	LobbyPrerequisiteCheckbox@GLOBALHUSK:
+		ID: husks
+		Label: Unit husks
+		Description: Vehicles and aircraft leave behind husks when they die
+		Enabled: False
+		DisplayOrder: 8
+		Prerequisites: global-husks
 	FrozenActorLayer:
 	BaseAttackNotifier:
 	PlayerStatistics:

--- a/mods/raclassic/rules/player.yaml
+++ b/mods/raclassic/rules/player.yaml
@@ -56,7 +56,7 @@ Player:
 		Prerequisites: global-factundeploy
 	LobbyPrerequisiteCheckbox@GLOBALHUSK:
 		ID: husks
-		Label: Unit husks
+		Label: Unit Husks
 		Description: Vehicles and aircraft leave behind husks when they die
 		Enabled: False
 		DisplayOrder: 8

--- a/mods/raclassic/rules/vehicles.yaml
+++ b/mods/raclassic/rules/vehicles.yaml
@@ -36,6 +36,10 @@ V2RL:
 	WithFacingSpriteBody@EMPTY:
 		RequiresCondition: !ammo
 		Sequence: empty-idle
+	SpawnActorOnDeath:
+		Actor: V2RL.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	SelectionDecorations:
 	Explodes:
 		Weapon: V2Explode
@@ -77,6 +81,8 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 1TNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 2TNK:
 	Inherits: ^Tank
@@ -113,6 +119,8 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 2TNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	SelectionDecorations:
 	Selectable:
 		DecorationBounds: 28,28
@@ -152,6 +160,8 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 3TNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	SelectionDecorations:
 	Selectable:
 		DecorationBounds: 28,28
@@ -198,6 +208,8 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 4TNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	SelfHealing:
 		Step: 1
 		Delay: 3
@@ -235,6 +247,10 @@ ARTY:
 		MuzzleSequence: muzzle
 	AttackFrontal:
 	WithMuzzleOverlay:
+	SpawnActorOnDeath:
+		Actor: ARTY.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	Explodes:
 		Weapon: ArtilleryExplode
 		EmptyWeapon: UnitExplodeSmall
@@ -277,6 +293,8 @@ HARV:
 	WithDockingAnimation:
 	SpawnActorOnDeath:
 		Actor: HARV.EmptyHusk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	HarvesterHuskModifier:
 		FullActor: HARV.FullHusk
 		FullnessThreshold: 50
@@ -321,6 +339,8 @@ MCV:
 	BaseBuilding:
 	SpawnActorOnDeath:
 		Actor: MCV.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 JEEP:
 	Inherits: ^Vehicle
@@ -350,6 +370,10 @@ JEEP:
 		Weapon: M60mg
 		MuzzleSequence: muzzle
 		LocalOffset: 128,0,43
+	SpawnActorOnDeath:
+		Actor: JEEP.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
@@ -392,6 +416,10 @@ APC:
 		PipCount: 5
 		LoadingCondition: notmobile
 		EjectOnDeath: true
+	SpawnActorOnDeath:
+		Actor: APC.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 MNLY.AP:
 	Inherits: ^Minelayer
@@ -404,6 +432,10 @@ MNLY.AP:
 		Name: Minelayer (Anti-Personnel)
 	Minelayer:
 		Mine: MINP
+	SpawnActorOnDeath:
+		Actor: MNLYAP.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 MNLY.AV:
 	Inherits: ^Minelayer
@@ -416,6 +448,10 @@ MNLY.AV:
 		Name: Minelayer (Anti-Tank)
 	Minelayer:
 		Mine: MINV
+	SpawnActorOnDeath:
+		Actor: MNLYAV.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 TRUK:
 	Inherits: ^Vehicle
@@ -433,6 +469,10 @@ TRUK:
 		Speed: 128
 	RevealsShroud:
 		Range: 4c0
+	SpawnActorOnDeath@1:
+		Actor: TRUK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 MGG:
 	Inherits: ^Vehicle
@@ -462,6 +502,8 @@ MGG:
 	RenderShroudCircle:
 	SpawnActorOnDeath:
 		Actor: MGG.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 MRJ:
 	Inherits: ^Vehicle
@@ -495,6 +537,10 @@ MRJ:
 		Type: jammer
 		Range: 15c0
 		Color: 0000FF80
+	SpawnActorOnDeath:
+		Actor: MRJ.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 TTNK:
 	Inherits: ^Tank
@@ -525,6 +571,10 @@ TTNK:
 	Turreted:
 	WithIdleOverlay@SPINNER:
 		Sequence: spinner
+	SpawnActorOnDeath:
+		Actor: TTNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	SelectionDecorations:
 	Selectable:
 		DecorationBounds: 30,30
@@ -557,6 +607,10 @@ DTRK:
 		RequiresCondition: invulnerability
 	Chronoshiftable:
 		ExplodeInstead: yes
+	SpawnActorOnDeath:
+		Actor: DTRK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 CTNK:
 	Inherits: ^Vehicle
@@ -592,6 +646,10 @@ CTNK:
 	AttackFrontal:
 	PortableChrono:
 		ChargeDelay: 300
+	SpawnActorOnDeath:
+		Actor: CTNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	Selectable:
 		DecorationBounds: 30,30
 
@@ -620,6 +678,10 @@ QTNK:
 	MadTank:
 	Targetable:
 		TargetTypes: Ground, MADTank, Repair, Vehicle
+	SpawnActorOnDeath:
+		Actor: QTNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	Selectable:
 		DecorationBounds: 44,38,0,-4
 
@@ -680,3 +742,7 @@ STNK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
 	-MustBeDestroyed:
+	SpawnActorOnDeath:
+		Actor: STNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true

--- a/mods/raclassic/rules/vehicles.yaml
+++ b/mods/raclassic/rules/vehicles.yaml
@@ -469,7 +469,7 @@ TRUK:
 		Speed: 128
 	RevealsShroud:
 		Range: 4c0
-	SpawnActorOnDeath@1:
+	SpawnActorOnDeath:
 		Actor: TRUK.Husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true

--- a/mods/raclassic/sequences/vehicles.yaml
+++ b/mods/raclassic/sequences/vehicles.yaml
@@ -16,6 +16,12 @@ truk:
 		UseClassicFacingFudge: True
 	icon: trukicon
 
+truk.destroyed:
+	idle: truk
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
+
 harv:
 	idle: harvempty
 		Facings: 32
@@ -174,6 +180,13 @@ v2rl:
 		Facings: 8
 	icon: v2rlicon
 
+v2rl.destroyed:
+	idle: v2rl
+		Start: 32
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
+
 arty:
 	idle:
 		Facings: 32
@@ -181,6 +194,12 @@ arty:
 	muzzle: gunfire2
 		Length: 5
 	icon: artyicon
+
+arty.destroyed:
+	idle: arty
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
 
 jeep:
 	idle:
@@ -194,6 +213,17 @@ jeep:
 		Length: 6
 		Facings: 8
 	icon: jeepicon
+
+jeep.destroyed:
+	idle: jeep
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
+	turret: jeep
+		Start: 32
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
 
 apc:
 	idle:
@@ -209,11 +239,23 @@ apc:
 		Start: 32
 	icon: apcicon
 
+apc.destroyed:
+	idle: apc
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
+
 mnly:
 	idle:
 		Facings: 32
 		UseClassicFacingFudge: True
 	icon: mnlyicon
+
+mnly.destroyed:
+	idle: mnly
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
 
 mrj:
 	idle:
@@ -223,6 +265,15 @@ mrj:
 		Start: 32
 		Length: 32
 	icon: mrjicon
+
+mrj.destroyed:
+	idle: mrj
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
+	spinner: mrj
+		Start: 32
+		Length: 1
 
 mgg:
 	idle:
@@ -257,11 +308,27 @@ ttnk:
 		Length: 32
 	icon: ttnkicon
 
+ttnk.destroyed:
+	idle: ttnk
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
+	spinner: ttnk
+		Start: 32
+		Length: 32
+		ZOffset: -512
+
 dtrk:
 	idle:
 		Facings: 32
 		UseClassicFacingFudge: True
 	icon: dtrkicon
+
+dtrk.destroyed:
+	idle: dtrk
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
 
 ctnk:
 	idle:
@@ -270,6 +337,12 @@ ctnk:
 	muzzle: gunfire2
 		Length: 5
 	icon: ctnkicon
+
+ctnk.destroyed:
+	idle: ctnk
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
 
 qtnk:
 	idle:
@@ -281,6 +354,17 @@ qtnk:
 		Length: 8
 	icon: qtnkicon
 
+qtnk.destroyed:
+	idle: qtnk
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
+	piston: qtnk
+		Start: 32
+		Facings: 8
+		Length: 1
+		ZOffset: -512
+
 stnk:
 	idle:
 		Facings: 32
@@ -289,3 +373,13 @@ stnk:
 		Start: 38
 		Facings: 32
 	icon: stnkicon
+
+stnk.destroyed:
+	idle: stnk
+		Facings: 32
+		UseClassicFacingFudge: True
+		ZOffset: -512
+	turret: stnk
+		Start: 38
+		Facings: 32
+		ZOffset: -512

--- a/mods/raclassic/weapons/explosions.yaml
+++ b/mods/raclassic/weapons/explosions.yaml
@@ -58,6 +58,14 @@ UnitExplode:
 	Warhead@1Dam: SpreadDamage
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 
+UnitExplodeAir:
+	Inherits: ^Explosion
+	-Warhead@Smu: LeaveSmudge
+	Warhead@2Eff: CreateEffect
+		Explosions: building
+		ImpactSounds: kaboom25.aud
+		ValidTargets: Air
+
 UnitExplodeShip:
 	Inherits: ^Explosion
 	-Warhead@Smu: LeaveSmudge


### PR DESCRIPTION
∙Adds the checkbox in the lobby. (off by default)
∙Adds the missing husks for the rest of the vehicles.
∙Adds a conditional visual explosion for destroyed airborne aircraft when husks are disabled.

*I wasn't able to test this as I am still unable to fetch the dependencies on windows.