### PR TITLE
Change movement speeds to match original

### DIFF
--- a/mods/raclassic/rules/aircraft.yaml
+++ b/mods/raclassic/rules/aircraft.yaml
@@ -9,7 +9,7 @@ BADR:
 	Aircraft:
 		CruiseAltitude: 2560
 		TurnSpeed: 5
-		Speed: 149
+		Speed: 160
 		Repulsable: False
 		MaximumPitch: 56
 	Cargo:
@@ -105,7 +105,7 @@ MIG:
 		CruiseAltitude: 2560
 		InitialFacing: 192
 		TurnSpeed: 5
-		Speed: 223
+		Speed: 200
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 		MoveIntoShroud: false
@@ -169,7 +169,7 @@ YAK:
 		CruiseAltitude: 2560
 		InitialFacing: 192
 		TurnSpeed: 5
-		Speed: 178
+		Speed: 160
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 		MoveIntoShroud: false
@@ -215,7 +215,7 @@ TRAN:
 	Aircraft:
 		InitialFacing: 224
 		TurnSpeed: 5
-		Speed: 128
+		Speed: 120
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Gems
 		AltitudeVelocity: 0c58
 		MoveIntoShroud: false
@@ -285,7 +285,7 @@ HELI:
 		LandWhenIdle: false
 		InitialFacing: 224
 		TurnSpeed: 4
-		Speed: 149
+		Speed: 160
 		MoveIntoShroud: false
 	AutoTarget:
 		InitialStance: HoldFire
@@ -352,7 +352,7 @@ HIND:
 		LandWhenIdle: false
 		InitialFacing: 224
 		TurnSpeed: 4
-		Speed: 112
+		Speed: 120
 		MoveIntoShroud: false
 	AutoTarget:
 		InitialStance: HoldFire
@@ -391,7 +391,7 @@ U2:
 	Aircraft:
 		CruiseAltitude: 2560
 		TurnSpeed: 7
-		Speed: 373
+		Speed: 400
 		Repulsable: False
 		MaximumPitch: 56
 	AttackBomber:

--- a/mods/raclassic/rules/defaults.yaml
+++ b/mods/raclassic/rules/defaults.yaml
@@ -138,11 +138,16 @@
 	SpawnActorOnDeath:
 		RequiresCondition: global-husks
 
+^GenericSpeedModifier:
+	SpeedMultiplier@Generic:
+		Modifier: 125
+
 ^Vehicle:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^IronCurtainable
 	Inherits@3: ^SpriteActor
 	Inherits@4: ^AffectedByCountryBonuses
+	Inherits@5: ^GenericSpeedModifier
 	Inherits@husks: ^GlobalHusks
 	Huntable:
 	OwnerLostAction:
@@ -233,6 +238,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Inherits@3: ^AffectedByCountryBonuses
+	Inherits@4: ^GenericSpeedModifier
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -244,7 +250,7 @@
 	RevealsShroud:
 		Range: 4c0
 	Mobile:
-		Speed: 56
+		Speed: 40
 		Locomotor: foot
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
@@ -334,6 +340,8 @@
 	Tooltip:
 		Name: Civilian
 		GenericVisibility: None
+	Mobile:
+		Speed: 50
 	RevealsShroud:
 		Range: 3c0
 	ProximityCaptor:
@@ -363,6 +371,7 @@
 	Inherits@2: ^IronCurtainable
 	Inherits@3: ^SpriteActor
 	Inherits@4: ^AffectedByCountryBonuses
+	Inherits@5: ^GenericSpeedModifier
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -408,6 +417,7 @@
 	Inherits@2: ^IronCurtainable
 	Inherits@3: ^SpriteActor
 	Inherits@4: ^AffectedByCountryBonuses
+	Inherits@5: ^GenericSpeedModifier
 	Inherits@husks: ^GlobalHusks
 	Huntable:
 	OwnerLostAction:
@@ -980,7 +990,7 @@
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 128
+		Speed: 90
 	RevealsShroud:
 		Range: 5c0
 	AmmoPool:

--- a/mods/raclassic/rules/infantry.yaml
+++ b/mods/raclassic/rules/infantry.yaml
@@ -23,7 +23,7 @@ DOG:
 	Health:
 		HP: 12
 	Mobile:
-		Speed: 99
+		Speed: 40
 		Voice: Move
 	Guard:
 		Voice: Move
@@ -102,7 +102,7 @@ E2:
 	Health:
 		HP: 50
 	Mobile:
-		Speed: 71
+		Speed: 50
 	Armament@PRIMARY:
 		Weapon: Grenade
 		LocalOffset: 0,0,555
@@ -136,6 +136,8 @@ E3:
 		Name: Rocket Soldier
 	Health:
 		HP: 45
+	Mobile:
+		Speed: 30
 	Armament@PRIMARY:
 		Weapon: RedEye
 		LocalOffset: 0,0,555
@@ -183,6 +185,8 @@ E4:
 		Name: Flamethrower
 	Health:
 		HP: 40
+	Mobile:
+		Speed: 30
 	Armament@PRIMARY:
 		Weapon: Flamer
 		LocalOffset: 700,0,400
@@ -281,7 +285,7 @@ E7:
 	Health:
 		HP: 100
 	Mobile:
-		Speed: 71
+		Speed: 50
 		Voice: Move
 	Guard:
 		Voice: Move
@@ -401,8 +405,6 @@ EINSTEIN:
 	-Wanders:
 	Tooltip:
 		Name: Prof. Einstein
-	Mobile:
-		Speed: 71
 	Voiced:
 		VoiceSet: EinsteinVoice
 
@@ -411,8 +413,6 @@ DELPHI:
 	-Wanders:
 	Tooltip:
 		Name: Agent Delphi
-	Mobile:
-		Speed: 71
 
 CHAN:
 	Inherits: ^CivInfantry
@@ -499,6 +499,7 @@ SHOK:
 	Health:
 		HP: 80
 	Mobile:
+		Speed: 30
 		Voice: Move
 	-Crushable:
 	Armament@PRIMARY:

--- a/mods/raclassic/rules/ships.yaml
+++ b/mods/raclassic/rules/ships.yaml
@@ -21,7 +21,7 @@ SS:
 		Type: Light
 	Mobile:
 		TurnSpeed: 7
-		Speed: 71
+		Speed: 60
 	RevealsShroud:
 		Range: 6c0
 	Targetable:
@@ -88,7 +88,7 @@ MSUB:
 		Type: Light
 	Mobile:
 		TurnSpeed: 7
-		Speed: 42
+		Speed: 50
 	RevealsShroud:
 		Range: 6c0
 	Targetable:
@@ -157,7 +157,7 @@ DD:
 		Type: Heavy
 	Mobile:
 		TurnSpeed: 7
-		Speed: 85
+		Speed: 60
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
@@ -228,8 +228,7 @@ CA:
 	Armor:
 		Type: Heavy
 	Mobile:
-		TurnSpeed: 5
-		Speed: 42
+		Speed: 40
 	RevealsShroud:
 		Range: 7c0
 	Turreted@PRIMARY:
@@ -288,7 +287,7 @@ LST:
 		Type: Heavy
 	Mobile:
 		TurnSpeed: 10
-		Speed: 113
+		Speed: 140
 		RequiresCondition: !notmobile
 	RevealsShroud:
 		Range: 6c0
@@ -328,7 +327,7 @@ PT:
 		Type: Heavy
 	Mobile:
 		TurnSpeed: 7
-		Speed: 128
+		Speed: 90
 	RevealsShroud:
 		Range: 7c0
 	Turreted:

--- a/mods/raclassic/rules/vehicles.yaml
+++ b/mods/raclassic/rules/vehicles.yaml
@@ -20,7 +20,7 @@ V2RL:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 85
+		Speed: 70
 	RevealsShroud:
 		Range: 5c0
 	Armament:
@@ -74,7 +74,7 @@ V2RL:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 128
+		Speed: 90
 	RevealsShroud:
 		Range: 4c0
 	Turreted:
@@ -119,7 +119,7 @@ V2RL:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 85
+		Speed: 80
 	RevealsShroud:
 		Range: 5c0
 	Turreted:
@@ -166,7 +166,7 @@ V2RL:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 71
+		Speed: 70
 	RevealsShroud:
 		Range: 5c0
 	Turreted:
@@ -210,7 +210,7 @@ V2RL:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 50
+		Speed: 40
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
@@ -287,7 +287,7 @@ ARTY:
 		Type: Light
 	Mobile:
 		TurnSpeed: 2
-		Speed: 85
+		Speed: 60
 	RevealsShroud:
 		Range: 5c0
 	Armament:
@@ -339,7 +339,7 @@ HARV:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 85
+		Speed: 60
 	RevealsShroud:
 		Range: 4c0
 	WithHarvestAnimation:
@@ -383,7 +383,7 @@ MCV:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 71
+		Speed: 60
 	RevealsShroud:
 		Range: 4c0
 	Transforms:
@@ -424,7 +424,7 @@ JEEP:
 		Type: Light
 	Mobile:
 		TurnSpeed: 10
-		Speed: 170
+		Speed: 100
 	RevealsShroud:
 		Range: 6c0
 	Turreted:
@@ -468,7 +468,7 @@ APC:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 142
+		Speed: 100
 		RequiresCondition: !notmobile
 	RevealsShroud:
 		Range: 5c0
@@ -547,7 +547,7 @@ TRUK:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 128
+		Speed: 100
 	RevealsShroud:
 		Range: 4c0
 	SpawnActorOnDeath:
@@ -573,7 +573,7 @@ MGG:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 99
+		Speed: 90
 	WithIdleOverlay@SPINNER:
 		Offset: -299,0,171
 		Sequence: spinner
@@ -609,7 +609,7 @@ MRJ:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 99
+		Speed: 90
 	RevealsShroud:
 		Range: 7c0
 	WithIdleOverlay@SPINNER:
@@ -654,7 +654,7 @@ TTNK:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 113
+		Speed: 80
 	RevealsShroud:
 		Range: 7c0
 	Armament:
@@ -692,7 +692,7 @@ DTRK:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 85
+		Speed: 80
 	RevealsShroud:
 		Range: 3c0
 	Explodes:
@@ -733,7 +733,7 @@ CTNK:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 113
+		Speed: 50
 	RevealsShroud:
 		Range: 5c0
 	Armament@PRIMARY:
@@ -787,7 +787,7 @@ QTNK:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 56
+		Speed: 30
 	RevealsShroud:
 		Range: 6c0
 	SelectionDecorations:
@@ -828,7 +828,7 @@ STNK:
 		TargetTypes: Ground, Vehicle
 		RequiresCondition: !parachute && cloaked
 	Mobile:
-		Speed: 142
+		Speed: 100
 		RequiresCondition: !notmobile
 	RevealsShroud:
 		Range: 5c0


### PR DESCRIPTION
I have no idea about the original calculations, i just wrote x10 of the original value and also put a 125% Modifier on all units because it normally felt low and i wanted to keep the actual speed values resemble the original. I did simiar thing on Generals Alpha too to use the original speed values.

This doesn't match the original 100% tho, it should be close enough and at least make the relative speeds to other units same as original.