### PR TITLE
Changes to aircraft to be more like original

### DIFF
--- a/mods/raclassic/rules/aircraft.yaml
+++ b/mods/raclassic/rules/aircraft.yaml
@@ -216,8 +216,6 @@ TRAN:
 		InitialFacing: 224
 		TurnSpeed: 5
 		Speed: 120
-		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Gems
-		AltitudeVelocity: 0c58
 		MoveIntoShroud: false
 	WithIdleOverlay@ROTOR1AIR:
 		Offset: 597,0,213
@@ -282,7 +280,6 @@ HELI:
 	AttackHeli:
 		FacingTolerance: 20
 	Aircraft:
-		LandWhenIdle: false
 		InitialFacing: 224
 		TurnSpeed: 4
 		Speed: 160
@@ -349,7 +346,6 @@ HIND:
 	AttackHeli:
 		FacingTolerance: 20
 	Aircraft:
-		LandWhenIdle: false
 		InitialFacing: 224
 		TurnSpeed: 4
 		Speed: 120

--- a/mods/raclassic/rules/defaults.yaml
+++ b/mods/raclassic/rules/defaults.yaml
@@ -433,6 +433,7 @@
 	Aircraft:
 		RepairBuildings: fix, fix.russia, fix.turkey
 		RearmBuildings: afld, afld.russia, afld.turkey
+		TakeOffOnCreation: false
 		AirborneCondition: airborne
 	Targetable@GROUND:
 		TargetTypes: Ground, Repair, Vehicle
@@ -450,6 +451,7 @@
 	ProximityExternalCondition:
 		Condition: unit.docked
 		Range: 1c0
+		RequiresCondition: !airborne
 	ExternalCondition@Sellable:
 		Condition: unit.sellable
 	AttackMove:
@@ -495,7 +497,8 @@
 		CanHover: True
 		CruisingCondition: cruising
 		WaitDistanceFromResupplyBase: 4c0
-		TakeOffOnResupply: true
+		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Gems
+		AltitudeVelocity: 0c58
 		VTOL: true
 	Hovers@CRUISING:
 		RequiresCondition: cruising

--- a/mods/raclassic/rules/structures.yaml
+++ b/mods/raclassic/rules/structures.yaml
@@ -1062,13 +1062,30 @@ HPAD:
 		ExitCell: 0,0
 		MoveIntoWorld: false
 		Facing: 224
-	RallyPoint:
 	Production:
 		Produces: Aircraft, Helicopter
+		RequiresCondition: !unit.docked
+	ProductionFromMapEdge:
+		Produces: Aircraft, Helicopter
+		RequiresCondition: !availablehpads
 	Reservable:
 	ProductionBar:
+		ProductionType: Aircraft
+	GrantConditionOnPrerequisite@PFME:
+		Condition: availablehpads
+		Prerequisites: availablehpads
+	ProvidesPrerequisite@PFME:
+		Prerequisite: availablehpads
+		RequiresCondition: !unit.docked
 	PrimaryBuilding:
 		PrimaryCondition: primary
+	ProximityExternalCondition:
+		Condition: unit.sellable
+		Range: 1c0
+	Sellable:
+		RequiresCondition: !unit.docked
+	ExternalCondition@Docked:
+		Condition: unit.docked
 	Power:
 		Amount: -10
 	ProvidesPrerequisite@allies:
@@ -1131,7 +1148,6 @@ AFLD:
 		ExitCell: 1,1
 		Facing: 192
 		MoveIntoWorld: false
-	RallyPoint:
 	Production:
 		Produces: Aircraft, Plane
 	Reservable:
@@ -1180,6 +1196,13 @@ AFLD:
 	SupportPowerChargeBar:
 	PrimaryBuilding:
 		PrimaryCondition: primary
+	ProximityExternalCondition:
+		Condition: unit.sellable
+		Range: 1c0
+	Sellable:
+		RequiresCondition: !unit.docked
+	ExternalCondition@Docked:
+		Condition: unit.docked
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:


### PR DESCRIPTION
Aircraft don't take off on creation/rearm.

Helipad can build out of map if all the helipads are occupied.

All the helis can land on ground.

You can sell Aircraft on HPAD/AFLD properly.

Aircraft no longer apply docked condition while flying over FIX.

Airfield and Helipad no longer has Rally Point, as now new aircraft is docked, also ProductionFromMapEdge don't work properly with it.