### PR TITLE
Changes to Greek Power Bonus

### DIFF
--- a/mods/raclassic/rules/country-duplicates.yaml
+++ b/mods/raclassic/rules/country-duplicates.yaml
@@ -10,8 +10,14 @@ POWR.greece:
 	Inherits: POWR
 	Buildable:
 		Prerequisites: ~player.greece, ~techlevel.1
-	Power:
-		Amount: 110
+	Power@1:
+		RequiresCondition: notgreece
+	Power@2:
+		RequiresCondition: !notgreece
+	-GrantConditionOnPrerequisite@Greece:
+	GrantConditionOnPrerequisite@NotGreece:
+		Condition: notgreece
+		Prerequisites: player.not_greece
 
 POWR.turkey:
 	Inherits: POWR
@@ -30,8 +36,14 @@ APWR.greece:
 	Inherits: APWR
 	Buildable:
 		Prerequisites: anypower, ~player.greece, ~techlevel.5
-	Power:
-		Amount: 220
+	Power@1:
+		RequiresCondition: notgreece
+	Power@2:
+		RequiresCondition: !notgreece
+	-GrantConditionOnPrerequisite@Greece:
+	GrantConditionOnPrerequisite@NotGreece:
+		Condition: notgreece
+		Prerequisites: player.not_greece
 
 APWR.turkey:
 	Inherits: APWR

--- a/mods/raclassic/rules/player.yaml
+++ b/mods/raclassic/rules/player.yaml
@@ -129,6 +129,9 @@ Player:
 	ProvidesPrerequisite@Normal_power:
 		Factions: allies, england, germany, france, spain, soviet, ukraine
 		Prerequisite: player.normal_power
+	ProvidesPrerequisite@NotGreece:
+		Factions: allies, england, germany, france, spain, turkey, soviet, russia, ukraine
+		Prerequisite: player.not_greece
 	ProvidesPrerequisite@England:
 		Factions: england
 		Prerequisite: player.england

--- a/mods/raclassic/rules/structures.yaml
+++ b/mods/raclassic/rules/structures.yaml
@@ -1253,8 +1253,15 @@ POWR:
 	RevealsShroud:
 		Range: 4c0
 	WithBuildingBib:
-	Power:
+	Power@1:
 		Amount: 100
+		RequiresCondition: !greece
+	Power@2:
+		Amount: 125
+		RequiresCondition: greece
+	GrantConditionOnPrerequisite@Greece:
+		Condition: greece
+		Prerequisites: player.greece
 	Targetable:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
 	ScalePowerWithHealth:
@@ -1295,8 +1302,15 @@ APWR:
 	RevealsShroud:
 		Range: 4c0
 	WithBuildingBib:
-	Power:
+	Power@1:
 		Amount: 200
+		RequiresCondition: !greece
+	Power@2:
+		Amount: 250
+		RequiresCondition: greece
+	GrantConditionOnPrerequisite@Greece:
+		Condition: greece
+		Prerequisites: player.greece
 	Targetable:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
 	ScalePowerWithHealth:

--- a/mods/raclassic/rules/world.yaml
+++ b/mods/raclassic/rules/world.yaml
@@ -105,7 +105,7 @@
 		Name: Greece
 		Side: Allies
 		InternalName: greece
-		Description: Greece\nGreece has 10% power output bonus on all power plants.
+		Description: Greece\nGreece has 25% power output bonus on all power plants.
 	Faction@turkey:
 		Name: Turkey
 		Side: Allies


### PR DESCRIPTION
Increased bonus to 25%.

Like other bonuses, other factions can no longer get the bonus by capturing greek PP. Similarly, when a greek captures a normal PP, they'll have extra power from it.