### PR TITLE
Adjust projectile speeds

### DIFF
--- a/mods/raclassic/weapons/ballistics.yaml
+++ b/mods/raclassic/weapons/ballistics.yaml
@@ -3,7 +3,7 @@
 	Range: 4c768
 	Report: cannon1.aud
 	Projectile: Bullet
-		Speed: 682
+		Speed: 600
 		Image: 120MM
 		Shadow: True
 	Warhead@1Dam: SpreadDamage
@@ -35,7 +35,6 @@
 	Range: 4c0
 	Report: cannon2.aud
 	Projectile: Bullet
-		Speed: 682
 		Image: 50CAL
 	Warhead@1Dam: SpreadDamage
 		Damage: 25
@@ -65,6 +64,8 @@
 	ReloadDelay: 80
 	Burst: 2
 	InvalidTargets: Air, Infantry
+	Projectile: Bullet
+		Speed: 450
 	Warhead@1Dam: SpreadDamage
 		Damage: 40
 
@@ -85,7 +86,7 @@ TurretGun:
 	ReloadDelay: 65
 	Range: 6c0
 	Projectile: Bullet
-		Speed: 204
+		Speed: 188
 		Blockable: false
 		LaunchAngle: 62
 	Warhead@1Dam: SpreadDamage
@@ -116,6 +117,7 @@ TurretGun:
 	Report: turret1.aud
 	TargetActorCenter: true
 	Projectile: Bullet
+		Speed: 93
 		Inaccuracy: 2c938
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
@@ -137,7 +139,7 @@ TurretGun:
 	Report: cannon2.aud
 	InvalidTargets: Underwater
 	Projectile: Bullet
-		Speed: 426
+		Speed: 375
 	Warhead@1Dam: SpreadDamage
 		Damage: 25
 
@@ -151,7 +153,7 @@ Grenade:
 	Range: 4c0
 	Report: grenade1.aud
 	Projectile: Bullet
-		Speed: 136
+		Speed: 75
 		Inaccuracy: 554
 		Image: BOMB
 	Warhead@1Dam: SpreadDamage
@@ -176,7 +178,7 @@ DepthCharge:
 	Range: 5c0
 	ValidTargets: Underwater
 	Projectile: Bullet
-		Speed: 85
+		Speed: 75
 		Image: BOMB
 		Inaccuracy: 128
 	Warhead@1Dam: SpreadDamage

--- a/mods/raclassic/weapons/missiles.yaml
+++ b/mods/raclassic/weapons/missiles.yaml
@@ -4,7 +4,7 @@
 	MinRange: 0c512
 	Report: missile6.aud
 	Projectile: Missile
-		Speed: 213
+		Speed: 375
 		Arm: 2
 		Blockable: false
 		Inaccuracy: 128
@@ -51,7 +51,7 @@ Maverick:
 	Report: missile7.aud
 	Burst: 2
 	Projectile: Missile
-		Speed: 256
+		Speed: 375
 		Inaccuracy: 512
 		CruiseAltitude: 2c0
 		RangeLimit: 9c410
@@ -79,7 +79,7 @@ Hellfire:
 	MinRange: 1c256
 	Burst: 2
 	Projectile: Missile
-		Speed: 256
+		Speed: 450
 		HorizontalRateOfTurn: 10
 		RangeLimit: 5c512
 	Warhead@1Dam: SpreadDamage
@@ -103,7 +103,7 @@ MammothTusk:
 	Burst: 2
 	ValidTargets: Air, Infantry
 	Projectile: Missile
-		Speed: 341
+		Speed: 450
 		HorizontalRateOfTurn: 15
 		RangeLimit: 9c614
 	Warhead@1Dam: SpreadDamage
@@ -142,7 +142,7 @@ Nike:
 		Image: MISSILE
 		HorizontalRateOfTurn: 25
 		RangeLimit: 9c0
-		Speed: 341
+		Speed: 750
 	Warhead@1Dam: SpreadDamage
 		Damage: 50
 		ValidTargets: Air
@@ -181,7 +181,7 @@ Stinger:
 		Inaccuracy: 0
 		HorizontalRateOfTurn: 20
 		RangeLimit: 9c512
-		Speed: 170
+		Speed: 300
 		CloseEnough: 149
 	Warhead@1Dam: SpreadDamage
 		Damage: 30
@@ -201,7 +201,6 @@ StingerAA:
 	Inherits: Stinger
 	ValidTargets: Air
 	Projectile: Missile
-		Speed: 255
 		CloseEnough: 298
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion_air
@@ -218,7 +217,7 @@ APTusk:
 	ReloadDelay: 80
 	Range: 5c0
 	Projectile: Missile
-		Speed: 298
+		Speed: 450
 		HorizontalRateOfTurn: 10
 		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
@@ -245,7 +244,7 @@ TorpTube:
 	Projectile: Missile
 		Image: torpedo
 		Arm: 3
-		Speed: 85
+		Speed: 225
 		TrailImage: bubbles
 		HorizontalRateOfTurn: 1
 		RangeLimit: 10c819
@@ -286,7 +285,7 @@ SubSCUD:
 	TargetActorCenter: true
 	Burst: 2
 	Projectile: Missile
-		Speed: 234
+		Speed: 300
 		Inaccuracy: 0c614
 		HorizontalRateOfTurn: 5
 		RangeLimit: 15c0
@@ -323,7 +322,7 @@ SCUD:
 	Report: missile1.aud
 	-Projectile:
 	Projectile: Bullet
-		Speed: 170
+		Speed: 375
 		Blockable: false
 		TrailImage: smokey
 		TrailDelay: 5

--- a/mods/raclassic/weapons/other.yaml
+++ b/mods/raclassic/weapons/other.yaml
@@ -1,9 +1,9 @@
 ^FireWeapon:
 	ValidTargets: Ground, Water, Trees
 	ReloadDelay: 50
-	Range: 4c0
+	Range: 5c0
 	Warhead@1Dam: SpreadDamage
-		Spread: 341
+		Spread: 213
 		Damage: 125
 		ValidTargets: Ground, Water, Trees
 		Versus:
@@ -24,7 +24,7 @@
 FireballLauncher:
 	Inherits: ^FireWeapon
 	Projectile: Bullet
-		Speed: 250
+		Speed: 188
 		TrailImage: fb2
 		TrailInterval: 1
 		Image: FB1
@@ -33,7 +33,7 @@ Flamer:
 	Inherits: ^FireWeapon
 	Range: 3c512
 	Projectile: Bullet
-		Speed: 250
+		Speed: 188
 		TrailImage: fb2
 		TrailInterval: 1
 		Image: FB1


### PR DESCRIPTION
Some units (Artillery, Grenadier, Cruiser) feel wrong. I feel like in the original distance actually effects the projectile speed. Because i tested with Cruiser and make it fire really close, projectile is slow, when firing far it is faster.

Arty and Gren are meh. Cruiser feels really wrong, tho lets keep it like that for now, it was pretty OP in original.