### PR TITLE
Remove aircraft Husks and AttackBombers from map editor

### DIFF
--- a/mods/raclassic/rules/aircraft.yaml
+++ b/mods/raclassic/rules/aircraft.yaml
@@ -67,6 +67,7 @@ BADR.Bomber:
 		Offset: -432,-560,0
 		Interval: 2
 	RejectsOrders:
+	-MapEditorData:
 	RenderSprites:
 		Image: badr
 	GivesExperience:
@@ -416,3 +417,4 @@ U2:
 		Interval: 2
 	RejectsOrders:
 	Interactable:
+	-MapEditorData:

--- a/mods/raclassic/rules/defaults.yaml
+++ b/mods/raclassic/rules/defaults.yaml
@@ -914,8 +914,7 @@
 		Spins: False
 		Moves: True
 		Velocity: 86
-	MapEditorData:
-		Categories: Husk
+	-MapEditorData:
 	RevealOnDeath:
 		Duration: 60
 		Radius: 4c0
@@ -934,6 +933,7 @@
 	FallsToEarth:
 	BodyOrientation:
 		UseClassicFacingFudge: True
+	-MapEditorData:
 	RevealOnDeath:
 		Duration: 60
 		Radius: 4c0


### PR DESCRIPTION
They are removed in upsteram too.

Tho, i just noticed we should probably remove the faction duplicates too, as i removed D2k starport units at upstream.