### PR TITLE
Remove Country Duplicates and Mission C. Wall from Map Editor

### DIFF
--- a/mods/raclassic/rules/country-duplicates.yaml
+++ b/mods/raclassic/rules/country-duplicates.yaml
@@ -1,6 +1,7 @@
 # BUILDINGS
 POWR.russia:
 	Inherits: POWR
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~player.russia, ~techlevel.1
 	Valued:
@@ -8,6 +9,7 @@ POWR.russia:
 
 POWR.greece:
 	Inherits: POWR
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~player.greece, ~techlevel.1
 	Power@1:
@@ -21,12 +23,14 @@ POWR.greece:
 
 POWR.turkey:
 	Inherits: POWR
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~player.turkey, ~techlevel.1
 
 APWR.russia:
 	Inherits: APWR
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-power, ~player.russia, ~techlevel.5
 	Valued:
@@ -34,6 +38,7 @@ APWR.russia:
 
 APWR.greece:
 	Inherits: APWR
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-power, ~player.greece, ~techlevel.5
 	Power@1:
@@ -47,12 +52,14 @@ APWR.greece:
 
 APWR.turkey:
 	Inherits: APWR
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-power, ~player.turkey, ~techlevel.5
 
 TENT.russia:
 	Inherits: TENT
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-power, ~structures.allies, ~player.russia, ~techlevel.1
 	Valued:
@@ -60,12 +67,14 @@ TENT.russia:
 
 TENT.turkey:
 	Inherits: TENT
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-power, ~structures.allies, ~player.turkey, ~techlevel.1
 
 BARR.russia:
 	Inherits: BARR
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-power, ~structures.soviet, ~player.russia, ~techlevel.1
 	Valued:
@@ -73,12 +82,14 @@ BARR.russia:
 
 BARR.turkey:
 	Inherits: BARR
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-power, ~structures.soviet, ~player.turkey, ~techlevel.1
 
 KENN.russia:
 	Inherits: KENN
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-barr, ~structures.soviet, ~player.russia, ~techlevel.2
 	Valued:
@@ -86,12 +97,14 @@ KENN.russia:
 
 KENN.turkey:
 	Inherits: KENN
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-barr, ~structures.soviet, ~player.turkey, ~techlevel.2
 
 PROC.russia:
 	Inherits: PROC
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-power, ~player.russia, ~techlevel.1
 	Valued:
@@ -101,6 +114,7 @@ PROC.russia:
 
 PROC.turkey:
 	Inherits: PROC
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-power, ~player.turkey, ~techlevel.1
@@ -109,6 +123,7 @@ PROC.turkey:
 
 SILO.russia:
 	Inherits: SILO
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-proc, ~player.russia, ~techlevel.1
 	Valued:
@@ -116,12 +131,14 @@ SILO.russia:
 
 SILO.turkey:
 	Inherits: SILO
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-proc, ~player.turkey, ~techlevel.1
 
 SYRD.russia:
 	Inherits: SYRD
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-power, ~structures.allies, ~player.russia, ~techlevel.2
 	Valued:
@@ -129,12 +146,14 @@ SYRD.russia:
 
 SYRD.turkey:
 	Inherits: SYRD
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-power, ~structures.allies, ~player.turkey, ~techlevel.2
 
 SPEN.russia:
 	Inherits: SPEN
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-power, ~structures.soviet, ~player.russia, ~techlevel.2
 	Valued:
@@ -142,12 +161,14 @@ SPEN.russia:
 
 SPEN.turkey:
 	Inherits: SPEN
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-power, ~structures.soviet, ~player.turkey, ~techlevel.2
 
 WEAP.russia:
 	Inherits: WEAP
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-proc, ~player.russia, ~techlevel.2
 	Valued:
@@ -155,12 +176,14 @@ WEAP.russia:
 
 WEAP.turkey:
 	Inherits: WEAP
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-proc, ~player.turkey, ~techlevel.2
 
 FIX.russia:
 	Inherits: FIX
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-weap, ~player.russia, ~techlevel.2
 	Valued:
@@ -168,12 +191,14 @@ FIX.russia:
 
 FIX.turkey:
 	Inherits: FIX
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-weap, ~player.turkey, ~techlevel.2
 
 DOME.russia:
 	Inherits: DOME
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-proc, ~player.russia, ~techlevel.2
 	Valued:
@@ -181,12 +206,14 @@ DOME.russia:
 
 DOME.turkey:
 	Inherits: DOME
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-proc, ~player.turkey, ~techlevel.2
 
 HPAD.russia:
 	Inherits: HPAD
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-dome, ~player.russia, ~techlevel.6
 	Valued:
@@ -194,12 +221,14 @@ HPAD.russia:
 
 HPAD.turkey:
 	Inherits: HPAD
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-dome, ~player.turkey, ~techlevel.6
 
 AFLD.russia:
 	Inherits: AFLD
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-dome, ~structures.soviet, ~player.russia, ~techlevel.3
 	Valued:
@@ -207,12 +236,14 @@ AFLD.russia:
 
 AFLD.turkey:
 	Inherits: AFLD
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-dome, ~structures.soviet, ~player.turkey, ~techlevel.3
 
 ATEK.russia:
 	Inherits: ATEK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-weap, building-dome, ~structures.allies, ~player.russia, ~techlevel.7
 	Valued:
@@ -220,12 +251,14 @@ ATEK.russia:
 
 ATEK.turkey:
 	Inherits: ATEK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-weap, building-dome, ~structures.allies, ~player.turkey, ~techlevel.7
 
 STEK.russia:
 	Inherits: STEK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-weap, building-dome, ~structures.soviet, ~player.russia, ~techlevel.4
 	Valued:
@@ -233,12 +266,14 @@ STEK.russia:
 
 STEK.turkey:
 	Inherits: STEK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-weap, building-dome, ~structures.soviet, ~player.turkey, ~techlevel.4
 
 PDOX.russia:
 	Inherits: PDOX
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-atek, !enoughpdox, ~structures.allies, ~player.russia, ~techlevel.9
 	Valued:
@@ -246,12 +281,14 @@ PDOX.russia:
 
 PDOX.turkey:
 	Inherits: PDOX
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-atek, !enoughpdox, ~structures.allies, ~player.turkey, ~techlevel.9
 
 IRON.russia:
 	Inherits: IRON
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-stek, !enoughiron, ~structures.soviet, ~!global-missionrules, ~player.russia, ~techlevel.9
 	Valued:
@@ -259,12 +296,14 @@ IRON.russia:
 
 IRON.turkey:
 	Inherits: IRON
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: stek, !enoughiron, ~structures.soviet, ~!global-missionrules, ~player.turkey, ~techlevel.9
 
 IRON.mission.russia:
 	Inherits: IRON.mission
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-stek, !enoughiron, ~structures.soviet, ~global-missionrules, ~player.russia, ~techlevel.9
 	Valued:
@@ -272,12 +311,14 @@ IRON.mission.russia:
 
 IRON.mission.turkey:
 	Inherits: IRON.mission
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: stek, !enoughiron, ~structures.soviet, ~global-missionrules, ~player.turkey, ~techlevel.9
 
 MSLO.russia:
 	Inherits: MSLO
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-tech, !enoughmslo, ~player.russia, ~techlevel.10
 	Valued:
@@ -285,6 +326,7 @@ MSLO.russia:
 
 MSLO.turkey:
 	Inherits: MSLO
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-tech, !enoughmslo, ~player.turkey, ~techlevel.10
@@ -292,6 +334,7 @@ MSLO.turkey:
 # DEFENSES
 SBAG.russia:
 	Inherits: SBAG
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~structures.allies, ~player.russia, ~techlevel.1
 	Valued:
@@ -299,12 +342,14 @@ SBAG.russia:
 
 SBAG.turkey:
 	Inherits: SBAG
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~structures.allies, ~player.turkey, ~techlevel.1
 
 FENC.russia:
 	Inherits: FENC
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~structures.soviet, ~player.russia, ~techlevel.1
 	Valued:
@@ -312,12 +357,14 @@ FENC.russia:
 
 FENC.turkey:
 	Inherits: FENC
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~structures.soviet, ~player.turkey, ~techlevel.1
 
 BRIK.russia:
 	Inherits: BRIK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~!global-missionrules, ~player.russia, ~techlevel.5
 	Valued:
@@ -325,6 +372,7 @@ BRIK.russia:
 
 BRIK.turkey:
 	Inherits: BRIK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~!global-missionrules, ~player.turkey, ~techlevel.5
@@ -344,6 +392,7 @@ BRIK.mission.turkey:
 
 PBOX.russia:
 	Inherits: PBOX
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-tent, ~structures.allies, ~player.russia, ~techlevel.1
 	Valued:
@@ -351,12 +400,14 @@ PBOX.russia:
 
 PBOX.turkey:
 	Inherits: PBOX
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-tent, ~structures.allies, ~player.turkey, ~techlevel.1
 
 HBOX.russia:
 	Inherits: HBOX
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-tent, ~structures.allies, ~player.russia, ~techlevel.2
 	Valued:
@@ -364,12 +415,14 @@ HBOX.russia:
 
 HBOX.turkey:
 	Inherits: HBOX
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-tent, ~structures.allies, ~player.turkey, ~techlevel.2
 
 FTUR.russia:
 	Inherits: FTUR
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-barr, ~structures.soviet, ~player.russia, ~techlevel.1
 	Valued:
@@ -377,12 +430,14 @@ FTUR.russia:
 
 FTUR.turkey:
 	Inherits: FTUR
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-barr, ~structures.soviet, ~player.turkey, ~techlevel.1
 
 GUN.russia:
 	Inherits: GUN
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-tent, ~structures.allies, ~!global-missionrules, ~player.russia, ~techlevel.2
 	Valued:
@@ -390,12 +445,14 @@ GUN.russia:
 
 GUN.turkey:
 	Inherits: GUN
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-tent, ~structures.allies, ~!global-missionrules, ~player.turkey, ~techlevel.2
 
 GUN.mission.russia:
 	Inherits: GUN.mission
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-tent, ~structures.allies, ~global-missionrules, ~player.russia, ~techlevel.2
 	Valued:
@@ -403,12 +460,14 @@ GUN.mission.russia:
 
 GUN.mission.turkey:
 	Inherits: GUN.mission
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-tent, ~structures.allies, ~global-missionrules, ~player.turkey, ~techlevel.2
 
 TSLA.russia:
 	Inherits: TSLA
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-weap, ~structures.soviet, ~!global-missionrules, ~player.russia, ~techlevel.5
 	Valued:
@@ -416,12 +475,14 @@ TSLA.russia:
 
 TSLA.turkey:
 	Inherits: TSLA
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-weap, ~structures.soviet, ~!global-missionrules, ~player.turkey, ~techlevel.5
 
 TSLA.mission.russia:
 	Inherits: TSLA.mission
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-weap, ~structures.soviet, ~global-missionrules, ~player.russia, ~techlevel.5
 	Valued:
@@ -429,12 +490,14 @@ TSLA.mission.russia:
 
 TSLA.mission.turkey:
 	Inherits: TSLA.mission
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-weap, ~structures.soviet, ~global-missionrules, ~player.turkey, ~techlevel.5
 
 AGUN.russia:
 	Inherits: AGUN
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-dome, ~structures.allies, ~player.russia, ~techlevel.3
 	Valued:
@@ -442,12 +505,14 @@ AGUN.russia:
 
 AGUN.turkey:
 	Inherits: AGUN
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-dome, ~structures.allies, ~player.turkey, ~techlevel.3
 
 SAM.russia:
 	Inherits: SAM
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-dome, ~structures.soviet, ~player.russia, ~techlevel.6
 	Valued:
@@ -455,12 +520,14 @@ SAM.russia:
 
 SAM.turkey:
 	Inherits: SAM
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-dome, ~structures.soviet, ~player.turkey, ~techlevel.6
 
 GAP.russia:
 	Inherits: GAP
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-atek, ~structures.allies, ~!global-missionrules, ~player.russia, ~techlevel.7
 	Valued:
@@ -468,12 +535,14 @@ GAP.russia:
 
 GAP.turkey:
 	Inherits: GAP
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-atek, ~structures.allies, ~!global-missionrules, ~player.turkey, ~techlevel.7
 
 GAP.mission.russia:
 	Inherits: GAP.mission
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-atek, ~structures.allies, ~global-missionrules, ~player.russia, ~techlevel.7
 	Valued:
@@ -481,6 +550,7 @@ GAP.mission.russia:
 
 GAP.mission.turkey:
 	Inherits: GAP.mission
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-atek, ~structures.allies, ~global-missionrules, ~player.turkey, ~techlevel.7
@@ -488,6 +558,7 @@ GAP.mission.turkey:
 # FAKES
 SYRF.russia:
 	Inherits: SYRF
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-power, ~structures.allies, ~player.russia, ~techlevel.2
 	Valued:
@@ -495,12 +566,14 @@ SYRF.russia:
 
 SYRF.turkey:
 	Inherits: SYRF
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-power, ~structures.allies, ~player.turkey, ~techlevel.2
 
 SPEF.russia:
 	Inherits: SPEF
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-power, ~disabled, ~player.russia, ~techlevel.2
 	Valued:
@@ -508,12 +581,14 @@ SPEF.russia:
 
 SPEF.turkey:
 	Inherits: SPEF
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-power, ~disabled, ~player.turkey, ~techlevel.2
 
 WEAF.russia:
 	Inherits: WEAF
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-proc, ~structures.allies, ~player.russia, ~techlevel.2
 	Valued:
@@ -521,12 +596,14 @@ WEAF.russia:
 
 WEAF.turkey:
 	Inherits: WEAF
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-proc, ~structures.allies, ~player.turkey, ~techlevel.2
 
 DOMF.russia:
 	Inherits: DOMF
+	-MapEditorData:
 	Buildable:
 		Prerequisites: building-proc, ~structures.allies, ~player.russia, ~techlevel.2
 	Valued:
@@ -534,12 +611,14 @@ DOMF.russia:
 
 DOMF.turkey:
 	Inherits: DOMF
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: building-proc, ~structures.allies, ~player.turkey, ~techlevel.2
 
 FACF.russia:
 	Inherits: FACF
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~structures.allies, ~player.russia, ~techlevel.1
 	Valued:
@@ -547,6 +626,7 @@ FACF.russia:
 
 FACF.turkey:
 	Inherits: FACF
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~structures.allies, ~player.turkey, ~techlevel.1
@@ -554,6 +634,7 @@ FACF.turkey:
 # INFANTRY
 DOG.russia:
 	Inherits: DOG
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~kenn, ~player.russia, ~techlevel.2
 	Valued:
@@ -561,12 +642,14 @@ DOG.russia:
 
 DOG.turkey:
 	Inherits: DOG
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~kenn, ~player.turkey, ~techlevel.2
 
 E1.russia:
 	Inherits: E1
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~barracks, ~player.russia, ~techlevel.1
 	Valued:
@@ -574,12 +657,14 @@ E1.russia:
 
 E1.turkey:
 	Inherits: E1
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~barracks, ~player.turkey, ~techlevel.1
 
 E2.russia:
 	Inherits: E2
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~barr, ~player.russia, ~techlevel.1
 	Valued:
@@ -587,12 +672,14 @@ E2.russia:
 
 E2.turkey:
 	Inherits: E2
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~barr, ~player.turkey, ~techlevel.1
 
 E3.russia:
 	Inherits: E3
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~barracks, ~player.russia, ~techlevel.1
 	Valued:
@@ -600,12 +687,14 @@ E3.russia:
 
 E3.turkey:
 	Inherits: E3
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~barracks, ~player.turkey, ~techlevel.1
 
 E4.russia:
 	Inherits: E4
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~barr, infantry-stek, ~player.russia, ~techlevel.4
 	Valued:
@@ -613,12 +702,14 @@ E4.russia:
 
 E4.turkey:
 	Inherits: E4
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~barr, infantry-stek, ~player.turkey, ~techlevel.4
 
 E6.russia:
 	Inherits: E6
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~barracks, ~player.russia, ~techlevel.3
 	Valued:
@@ -626,12 +717,14 @@ E6.russia:
 
 E6.turkey:
 	Inherits: E6
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~barracks, ~player.turkey, ~techlevel.3
 
 SPY.russia:
 	Inherits: SPY
+	-MapEditorData:
 	Buildable:
 		Prerequisites: infantry-dome, ~tent, ~player.russia, ~techlevel.4
 	Valued:
@@ -639,12 +732,14 @@ SPY.russia:
 
 SPY.turkey:
 	Inherits: SPY
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: infantry-dome, ~tent, ~player.turkey, ~techlevel.4
 
 E7.russia:
 	Inherits: E7
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~barracks, infantry-tech, ~player.russia, ~techlevel.8
 	Valued:
@@ -652,12 +747,14 @@ E7.russia:
 
 E7.turkey:
 	Inherits: E7
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~barracks, infantry-tech, ~player.turkey, ~techlevel.8
 
 MEDI.russia:
 	Inherits: MEDI
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~tent, ~player.russia, ~techlevel.1
 	Valued:
@@ -665,12 +762,14 @@ MEDI.russia:
 
 MEDI.turkey:
 	Inherits: MEDI
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~tent, ~player.turkey, ~techlevel.1
 
 MECH.russia:
 	Inherits: MECH
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~tent, infantry-fix, ~global-aftermath, ~player.russia, ~techlevel.5
 	Valued:
@@ -678,12 +777,14 @@ MECH.russia:
 
 MECH.turkey:
 	Inherits: MECH
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~tent, infantry-fix, ~global-aftermath, ~player.turkey, ~techlevel.5
 
 THF.russia:
 	Inherits: THF
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~tent, infantry-atek, ~player.russia, ~techlevel.8
 	Valued:
@@ -691,12 +792,14 @@ THF.russia:
 
 THF.turkey:
 	Inherits: THF
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~tent, infantry-atek, ~player.turkey, ~techlevel.8
 
 SHOK.russia:
 	Inherits: SHOK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~barr, infantry-tsla, ~global-aftermath, ~player.russia, ~techlevel.5
 	Valued:
@@ -704,6 +807,7 @@ SHOK.russia:
 
 SHOK.turkey:
 	Inherits: SHOK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~barr, infantry-tsla, ~global-aftermath, ~player.turkey, ~techlevel.5
@@ -711,6 +815,7 @@ SHOK.turkey:
 # VEHICLES
 V2RL.russia:
 	Inherits: V2RL
+	-MapEditorData:
 	Buildable:
 		Prerequisites: vehicle-dome, ~vehicles.soviet, ~player.russia, ~techlevel.2
 	Valued:
@@ -718,12 +823,14 @@ V2RL.russia:
 
 V2RL.turkey:
 	Inherits: V2RL
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: vehicle-dome, ~vehicles.soviet, ~player.turkey, ~techlevel.2
 
 1TNK.russia:
 	Inherits: 1TNK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.allies, ~player.russia, ~techlevel.2
 	Valued:
@@ -731,12 +838,14 @@ V2RL.turkey:
 
 1TNK.turkey:
 	Inherits: 1TNK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.allies, ~player.turkey, ~techlevel.2
 
 2TNK.russia:
 	Inherits: 2TNK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.allies, ~player.russia, ~techlevel.4
 	Valued:
@@ -744,12 +853,14 @@ V2RL.turkey:
 
 2TNK.turkey:
 	Inherits: 2TNK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.allies, ~player.turkey, ~techlevel.4
 
 3TNK.russia:
 	Inherits: 3TNK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.soviet, ~player.russia, ~techlevel.2
 	Valued:
@@ -757,12 +868,14 @@ V2RL.turkey:
 
 3TNK.turkey:
 	Inherits: 3TNK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.soviet, ~player.turkey, ~techlevel.2
 
 4TNK.russia:
 	Inherits: 4TNK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: vehicle-stek, ~vehicles.soviet, ~player.russia, ~techlevel.7
 	Valued:
@@ -770,12 +883,14 @@ V2RL.turkey:
 
 4TNK.turkey:
 	Inherits: 4TNK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: vehicle-stek, ~vehicles.soviet, ~player.turkey, ~techlevel.7
 
 ARTY.russia:
 	Inherits: ARTY
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.allies, ~player.russia, ~techlevel.5
 	Valued:
@@ -783,12 +898,14 @@ ARTY.russia:
 
 ARTY.turkey:
 	Inherits: ARTY
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.allies, ~player.turkey, ~techlevel.5
 
 HARV.russia:
 	Inherits: HARV
+	-MapEditorData:
 	Buildable:
 		Prerequisites: vehicle-proc, ~player.russia, ~techlevel.1
 	Valued:
@@ -796,12 +913,14 @@ HARV.russia:
 
 HARV.turkey:
 	Inherits: HARV
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: vehicle-proc, ~player.turkey, ~techlevel.1
 
 MCV.russia:
 	Inherits: MCV
+	-MapEditorData:
 	Buildable:
 		Prerequisites: vehicle-fix, ~player.russia, ~techlevel.8
 	Valued:
@@ -809,12 +928,14 @@ MCV.russia:
 
 MCV.turkey:
 	Inherits: MCV
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: vehicle-fix, ~player.turkey, ~techlevel.8
 
 JEEP.russia:
 	Inherits: JEEP
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.allies, ~player.russia, ~techlevel.2
 	Valued:
@@ -822,12 +943,14 @@ JEEP.russia:
 
 JEEP.turkey:
 	Inherits: JEEP
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.allies, ~player.turkey, ~techlevel.2
 
 APC.russia:
 	Inherits: APC
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.allies, vehicle-tent, ~player.russia, ~techlevel.3
 	Valued:
@@ -835,12 +958,14 @@ APC.russia:
 
 APC.turkey:
 	Inherits: APC
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.allies, vehicle-tent, ~player.turkey, ~techlevel.3
 
 MNLY.AP.russia:
 	Inherits: MNLY.AP
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.soviet, vehicle-fix, ~player.russia, ~techlevel.2
 	Valued:
@@ -848,12 +973,14 @@ MNLY.AP.russia:
 
 MNLY.AP.turkey:
 	Inherits: MNLY.AP
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.soviet, vehicle-fix, ~player.turkey, ~techlevel.2
 
 MNLY.AV.russia:
 	Inherits: MNLY.AV
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.allies, vehicle-fix, ~player.russia, ~techlevel.2
 	Valued:
@@ -861,12 +988,14 @@ MNLY.AV.russia:
 
 MNLY.AV.turkey:
 	Inherits: MNLY.AV
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.allies, vehicle-fix, ~player.turkey, ~techlevel.2
 
 MGG.russia:
 	Inherits: MGG
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.allies, vehicle-atek, ~player.russia, ~techlevel.8
 	Valued:
@@ -874,12 +1003,14 @@ MGG.russia:
 
 MGG.turkey:
 	Inherits: MGG
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.allies, vehicle-atek, ~player.turkey, ~techlevel.8
 
 MRJ.russia:
 	Inherits: MRJ
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.allies, vehicle-dome, ~player.russia, ~techlevel.9
 	Valued:
@@ -887,12 +1018,14 @@ MRJ.russia:
 
 MRJ.turkey:
 	Inherits: MRJ
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.allies, vehicle-dome, ~player.turkey, ~techlevel.9
 
 TTNK.russia:
 	Inherits: TTNK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.soviet, vehicle-tsla, ~global-aftermath, ~player.russia, ~techlevel.5
 	Valued:
@@ -900,12 +1033,14 @@ TTNK.russia:
 
 TTNK.turkey:
 	Inherits: TTNK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.soviet, vehicle-tsla, ~global-aftermath, ~player.turkey, ~techlevel.5
 
 DTRK.russia:
 	Inherits: DTRK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: vehicle-mslo, ~global-aftermath, ~player.russia, ~techlevel.10
 	Valued:
@@ -913,12 +1048,14 @@ DTRK.russia:
 
 DTRK.turkey:
 	Inherits: DTRK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: vehicle-mslo, ~global-aftermath, ~player.turkey, ~techlevel.10
 
 CTNK.russia:
 	Inherits: CTNK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.allies, vehicle-atek, ~global-aftermath, ~player.russia, ~techlevel.9
 	Valued:
@@ -926,12 +1063,14 @@ CTNK.russia:
 
 CTNK.turkey:
 	Inherits: CTNK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.allies, vehicle-atek, ~global-aftermath, ~player.turkey, ~techlevel.9
 
 QTNK.russia:
 	Inherits: QTNK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.soviet, vehicle-stek, ~global-aftermath, ~player.russia, ~techlevel.7
 	Valued:
@@ -939,12 +1078,14 @@ QTNK.russia:
 
 QTNK.turkey:
 	Inherits: QTNK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.soviet, vehicle-stek, ~global-aftermath, ~player.turkey, ~techlevel.7
 
 STNK.russia:
 	Inherits: STNK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~vehicles.allies, vehicle-atek, ~player.russia, ~disabled
 	Valued:
@@ -952,6 +1093,7 @@ STNK.russia:
 
 STNK.turkey:
 	Inherits: STNK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~vehicles.allies, vehicle-atek, ~player.turkey, ~disabled
@@ -959,6 +1101,7 @@ STNK.turkey:
 # SHIPS
 SS.russia:
 	Inherits: SS
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~spen, ~player.russia, ~techlevel.3
 	Valued:
@@ -966,12 +1109,14 @@ SS.russia:
 
 SS.turkey:
 	Inherits: SS
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~spen, ~player.turkey, ~techlevel.3
 
 MSUB.russia:
 	Inherits: MSUB
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~spen, naval-stek, ~global-aftermath, ~player.russia, ~techlevel.6
 	Valued:
@@ -979,12 +1124,14 @@ MSUB.russia:
 
 MSUB.turkey:
 	Inherits: MSUB
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~spen, naval-stek, ~global-aftermath, ~player.turkey, ~techlevel.6
 
 DD.russia:
 	Inherits: DD
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~syrd, ~player.russia, ~techlevel.5
 	Valued:
@@ -992,12 +1139,14 @@ DD.russia:
 
 DD.turkey:
 	Inherits: DD
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~syrd, ~player.turkey, ~techlevel.5
 
 CA.russia:
 	Inherits: CA
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~syrd, naval-atek, ~player.russia, ~techlevel.7
 	Valued:
@@ -1005,12 +1154,14 @@ CA.russia:
 
 CA.turkey:
 	Inherits: CA
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~syrd, naval-atek, ~player.turkey, ~techlevel.7
 
 LST.russia:
 	Inherits: LST
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~player.russia, ~techlevel.2
 	Valued:
@@ -1018,12 +1169,14 @@ LST.russia:
 
 LST.turkey:
 	Inherits: LST
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~player.turkey, ~techlevel.2
 
 PT.russia:
 	Inherits: PT
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~syrd, ~player.russia, ~techlevel.3
 	Valued:
@@ -1031,6 +1184,7 @@ PT.russia:
 
 PT.turkey:
 	Inherits: PT
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~syrd, ~player.turkey, ~techlevel.3
@@ -1038,6 +1192,7 @@ PT.turkey:
 # AIRCRAFT
 MIG.russia:
 	Inherits: MIG
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~afld, ~player.russia, ~techlevel.7
 	Valued:
@@ -1045,12 +1200,14 @@ MIG.russia:
 
 MIG.turkey:
 	Inherits: MIG
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~afld, ~player.turkey, ~techlevel.7
 
 YAK.russia:
 	Inherits: YAK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~afld, ~player.russia, ~techlevel.3
 	Valued:
@@ -1058,12 +1215,14 @@ YAK.russia:
 
 YAK.turkey:
 	Inherits: YAK
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~afld, ~player.turkey, ~techlevel.3
 
 TRAN.russia:
 	Inherits: TRAN
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~hpad, ~player.russia, ~techlevel.8
 	Valued:
@@ -1071,12 +1230,14 @@ TRAN.russia:
 
 TRAN.turkey:
 	Inherits: TRAN
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~hpad, ~player.turkey, ~techlevel.8
 
 HELI.russia:
 	Inherits: HELI
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~hpad, ~heli.allies, ~player.russia, ~techlevel.6
 	Valued:
@@ -1084,12 +1245,14 @@ HELI.russia:
 
 HELI.turkey:
 	Inherits: HELI
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~hpad, ~heli.allies, ~player.turkey, ~techlevel.6
 
 HIND.russia:
 	Inherits: HIND
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~hpad, ~heli.soviet, ~player.russia, ~techlevel.6
 	Valued:
@@ -1097,6 +1260,7 @@ HIND.russia:
 
 HIND.turkey:
 	Inherits: HIND
+	-MapEditorData:
 	Buildable:
 		BuildDurationModifier: 54
 		Prerequisites: ~hpad, ~heli.soviet, ~player.turkey, ~techlevel.6

--- a/mods/raclassic/rules/structures.yaml
+++ b/mods/raclassic/rules/structures.yaml
@@ -1946,6 +1946,7 @@ BRIK:
 
 BRIK.mission:
 	Inherits: BRIK
+	-MapEditorData:
 	Buildable:
 		Prerequisites: ~global-missionrules, ~player.normal, ~techlevel.5
 	Valued:


### PR DESCRIPTION
Other mission ruleset dupes has changes other than cost, so one or other being the preplaced one may matter, for Country Dupes and Mission Concrete Wall it doesn't.