### PR TITLE
Add Multi-Engineer checkbox

### DIFF
--- a/mods/raclassic/rules/infantry.yaml
+++ b/mods/raclassic/rules/infantry.yaml
@@ -252,11 +252,19 @@ E6:
 		PipType: Yellow
 	EngineerRepair:
 	RepairsBridges:
-	Captures:
+	Captures@Single:
+		CaptureTypes: building
+		PlayerExperience: 25
+		RequiresCondition: !multiengineer
+	Captures@Multi:
 		CaptureTypes: building
 		SabotageHPRemoval: 33
 		SabotageThreshold: 66
 		PlayerExperience: 25
+		RequiresCondition: multiengineer
+	GrantConditionOnPrerequisite@MULTIENGINEER:
+		Condition: multiengineer
+		Prerequisites: global-multiengineer
 	Voiced:
 		VoiceSet: EngineerVoice
 	RenderSprites:

--- a/mods/raclassic/rules/player.yaml
+++ b/mods/raclassic/rules/player.yaml
@@ -84,7 +84,7 @@ Player:
 		CashTickDownNotification: CashTickDown
 		InsufficientFundsNotification: InsufficientFunds
 	DeveloperMode:
-		CheckboxDisplayOrder: 14
+		CheckboxDisplayOrder: 17
 	GpsWatcher:
 	Shroud:
 		FogCheckboxEnabled: false
@@ -138,6 +138,13 @@ Player:
 		Enabled: False
 		DisplayOrder: 13
 		Prerequisites: global-autoscatter
+	LobbyPrerequisiteCheckbox@GLOBALMULTIENGINEER:
+		ID: multiengineer
+		Label: Multi Engineer
+		Description: Multiple Engineers are required to capture a building.
+		Enabled: True
+		DisplayOrder: 14
+		Prerequisites: global-multiengineer
 	LobbyPrerequisiteCheckbox@GLOBALBLOCKABLEBULLETS:
 		ID: blockablebullets
 		Label: Blockable Bullets


### PR DESCRIPTION
Enabled by default, disabling makes it so 1 engi can capture a building.