### PR TITLE
Fix Debug Menu crash.

### DIFF
--- a/mods/raclassic/chrome/ingame-player.yaml
+++ b/mods/raclassic/chrome/ingame-player.yaml
@@ -354,23 +354,6 @@ Container@PLAYER_WIDGETS:
 									X: 6
 									Y: 6
 									ImageCollection: order-icons
-						MenuButton@DEBUG_BUTTON:
-							Logic: AddFactionSuffixLogic
-							X: 160
-							Width: 28
-							Height: 28
-							Background: sidebar-button
-							Key: escape Shift
-							TooltipText: Debug Menu
-							TooltipContainer: TOOLTIP_CONTAINER
-							DisableWorldSounds: true
-							VisualHeight: 0
-							Children:
-								Image@ICON:
-									X: 6
-									Y: 6
-									ImageCollection: order-icons
-									ImageName: debug
 						MenuButton@OPTIONS_BUTTON:
 							Logic: AddFactionSuffixLogic
 							X: 192


### PR DESCRIPTION
This button is removed upstream, chrome.yaml seem to have been updated for this change but not ingame-player.yaml so it was crashing saying `debug` wasn't found under `order-icons`.